### PR TITLE
xenstore: add xss_rm() routine

### DIFF
--- a/xenstore-srv/include/xss.h
+++ b/xenstore-srv/include/xss.h
@@ -53,3 +53,10 @@ int xss_read_integer(const char *path, int *value);
  */
 int xss_set_perm(const char *path, domid_t domid, enum xs_perm perm);
 
+/*
+ * Removes the value associated with a path.
+ *
+ * @param path Xenstore path
+ * @return 0 on success, a negative errno value on error.
+ */
+int xss_rm(const char *path);

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -547,30 +547,41 @@ void remove_recurse(sys_dlist_t *chlds)
 	}
 }
 
-void handle_rm(struct xen_domain *domain, uint32_t id, char *payload, uint32_t len)
+static int xss_do_rm(struct xs_entry *entry)
 {
-	struct xs_entry *entry = key_to_entry(payload);
+	if (!entry)
+		return -EINVAL;
 
-	if (entry) {
-		if (entry->key) {
-			k_free(entry->key);
-			entry->key = NULL;
-		}
-
-		if (entry->value) {
-			k_free(entry->value);
-			entry->value = NULL;
-		}
-
-		k_mutex_lock(&xsel_mutex, K_FOREVER);
-		sys_dlist_remove(&entry->node);
-		sys_dlist_t chlds = entry->child_list;
-		k_free(entry);
-		k_mutex_unlock(&xsel_mutex);
-
-		remove_recurse(&chlds);
+	if (entry->key) {
+		k_free(entry->key);
+		entry->key = NULL;
 	}
 
+	if (entry->value) {
+		k_free(entry->value);
+		entry->value = NULL;
+	}
+
+	k_mutex_lock(&xsel_mutex, K_FOREVER);
+	sys_dlist_remove(&entry->node);
+	sys_dlist_t chlds = entry->child_list;
+
+	k_free(entry);
+	k_mutex_unlock(&xsel_mutex);
+
+	remove_recurse(&chlds);
+	return 0;
+}
+
+int xss_rm(const char *path)
+{
+	return xss_do_rm(key_to_entry(path));
+}
+
+void handle_rm(struct xen_domain *domain, uint32_t id, char *payload,
+	       uint32_t len)
+{
+	xss_do_rm(key_to_entry(payload));
 	send_reply_read(domain, id, XS_RM, "");
 }
 


### PR DESCRIPTION
This shall allow to do XenStore clean-ups on dom0 side, e.g. vchannel server must remove its XS entries when closing connection.