### PR TITLE
Fixups fixing build errors and warnings in Zephyr.

### DIFF
--- a/xen-dom-mgmt/include/xen-dom-fdt.h
+++ b/xen-dom-mgmt/include/xen-dom-fdt.h
@@ -10,6 +10,6 @@
 
 int gen_domain_fdt(struct xen_domain_cfg *domcfg, void **fdtaddr,
 		size_t *fdtsize, int xen_major, int xen_minor, void *pfdt,
-				   size_t pfdt_size, int domid);
+		size_t pfdt_size, int domid);
 
 #endif /* XENLIB_XEN_DOM_FDT_H */

--- a/xen-dom-mgmt/src/xen-dom-fdt.c
+++ b/xen-dom-mgmt/src/xen-dom-fdt.c
@@ -885,7 +885,7 @@ int gen_domain_fdt(struct xen_domain_cfg *domcfg, void **fdtaddr,
 #else /* CONFIG_XEN_LIBFDT */
 int gen_domain_fdt(struct xen_domain_cfg *domcfg, void **fdtaddr,
 		size_t *fdtsize, int xen_major, int xen_minor,
-		void *pfdt, size_t pfdt_size. int domid)
+		void *pfdt, size_t pfdt_size, int domid)
 {
 	printk("Domain device tree generation is not supported\n");
 	*fdtaddr = pfdt;

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -283,7 +283,7 @@ void load_dtb(int domid, uint64_t dtb_addr, const char *dtb_start, const char *d
 
 	mapped_dtb = k_aligned_alloc(XEN_PAGE_SIZE, XEN_PAGE_SIZE * nr_pages);
 	if (!mapped_dtb)
-		return -ENOMEM;
+		return;
 
 	mapped_dtb_pfn = xen_virt_to_gfn((uint64_t)mapped_dtb);
 


### PR DESCRIPTION
This MR includes 2 fixups:
1) Fixing build error if libfdt is not enabled
2) Fixing warning of returning value from void function