### PR TITLE
Introduce dt_passthrough node support for domcfg

### DIFF
--- a/xen-dom-mgmt/include/domain.h
+++ b/xen-dom-mgmt/include/domain.h
@@ -42,6 +42,9 @@ struct xen_domain_cfg {
 	char **dtdevs;
 	uint32_t nr_dtdevs;
 
+	char **dt_passthrough;
+	uint32_t nr_dt_passthrough;
+
 	char *cmdline;
 
 	const char *img_start, *img_end;

--- a/xen-dom-mgmt/include/xen-dom-fdt.h
+++ b/xen-dom-mgmt/include/xen-dom-fdt.h
@@ -12,4 +12,6 @@ int gen_domain_fdt(struct xen_domain_cfg *domcfg, void **fdtaddr,
 		size_t *fdtsize, int xen_major, int xen_minor, void *pfdt,
 		size_t pfdt_size, int domid);
 
+void free_domain_fdt(void *fdt);
+
 #endif /* XENLIB_XEN_DOM_FDT_H */

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -374,8 +374,9 @@ int probe_zimage(int domid, uint64_t base_addr, uint64_t image_load_offset,
 
 	dtb_addr = get_dtb_addr(base_addr, KB(domcfg->mem_kb), load_addr,
 				 domcfg->img_end - domcfg->img_start, fdt_size);
-	if (!dtb_addr)
-		return -ENOMEM;
+	if (!dtb_addr) {
+		goto out_dtb;
+	}
 
 	modules->dtb_addr = dtb_addr;
 
@@ -383,8 +384,9 @@ int probe_zimage(int domid, uint64_t base_addr, uint64_t image_load_offset,
 
 	mapped_domd = k_aligned_alloc(XEN_PAGE_SIZE, XEN_PAGE_SIZE * nr_pages);
 
-	if (mapped_domd == NULL)
-		return 0;
+	if (mapped_domd == NULL) {
+		goto out_dtb;
+	}
 
 	LOG_INF("Allocated %llu pages (%llu), mapped_domd = %p",
 		   nr_pages, XEN_PAGE_SIZE * nr_pages, mapped_domd);
@@ -435,6 +437,8 @@ int probe_zimage(int domid, uint64_t base_addr, uint64_t image_load_offset,
 	rc = 0;
  out:
 	k_free(mapped_domd);
+ out_dtb:
+	free_domain_fdt(fdt);
 
 	return rc;
 }


### PR DESCRIPTION
Add dt_passthrough support to domcfg as analogue to dt_passthrough nodes in xl.cfg
This will allow us to pass nodes, that should be copied to the Domain device tree without need to put them to /passthrough node.