### PR TITLE
xenstore-srv: refactor watch notification to avoid domain list reference

### DIFF
--- a/xenstore-srv/include/xenstore_srv.h
+++ b/xenstore-srv/include/xenstore_srv.h
@@ -21,7 +21,7 @@ struct xs_entry {
 struct watch_entry {
 	char *key;
 	char *token;
-	int domid;
+	struct xen_domain *domain;
 	bool is_relative;
 
 	sys_dnode_t node;
@@ -29,7 +29,7 @@ struct watch_entry {
 
 struct pending_watch_event_entry {
 	char *key;
-	int domid;
+	struct xen_domain *domain;
 
 	sys_dnode_t node;
 };


### PR DESCRIPTION
This commit changes Xenstore watches logic, to prevent xenstore-srv from using global domain list during watcher notification. Referencing to domain list without proper sycnronization between xen-dom-mgmt and xenstore-srv is risky and actually was not needed.

To notify watcher domain about file changes, we need to add pending event to global pevent list and notify domain with xb_sem. Previously, watch event holded only domid, which needed a domid_to_domain() calls for notification. Now we changed domid inside this structs to domain pointers to make direct notification possible and also fixed possible watches leaks during domain destroy. In this implementation all watches and pending events will be removed during domain destroy.