### PR TITLE
mem-mgmt: implement helper functions for memory management

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -39,3 +39,10 @@ config XEN_VCH
 	bool "Enable Xen vchannels support"
 	help
 	  Enable vchannel communication library.
+
+config PFN_CHUNK_SIZE
+	int "Chunk size for memory mapping operations"
+	default 128
+	help
+	  Chunk size for helper functions for mapping/unmapping
+	  memory from guest domain to Dom0.

--- a/xen-dom-mgmt/CMakeLists.txt
+++ b/xen-dom-mgmt/CMakeLists.txt
@@ -5,6 +5,6 @@ add_library(XENDOM_MGMT INTERFACE)
 target_include_directories(XENDOM_MGMT INTERFACE include)
 
 zephyr_library()
-zephyr_library_sources(src/xen-dom-mgmt.c src/xen-dom-fdt.c)
+zephyr_library_sources(src/xen-dom-mgmt.c src/xen-dom-fdt.c src/mem-mgmt.c)
 zephyr_library_link_libraries(XENDOM_MGMT)
 zephyr_include_directories(include)

--- a/xen-dom-mgmt/include/mem-mgmt.h
+++ b/xen-dom-mgmt/include/mem-mgmt.h
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2023 EPAM Systems
+ */
+
+#ifndef XENLIB_XEN_MEM_MGMT_H
+#define XENLIB_XEN_MEM_MGMT_H
+
+#include <domain.h>
+
+#define LPAE_SHIFT (9)
+#define PFN_4K_SHIFT (0)
+#define PFN_2M_SHIFT (PFN_4K_SHIFT + LPAE_SHIFT)
+#define PFN_1G_SHIFT (PFN_2M_SHIFT + LPAE_SHIFT)
+
+#define PFN_4K_SIZE (4096)
+#define PFN_2M_SIZE (PFN_4K_SIZE << LPAE_SHIFT)
+#define PFN_1G_SIZE (PFN_2M_SIZE << LPAE_SHIFT)
+
+/*
+ * Allocates memory in Dom0 and maps guest memory to this region.
+ * In case of any error, the function will try to restore
+ * memory and return error code.
+ *
+ * @param domid - domain ID which memory will be mapped
+ * @param nr_pages - number of pages with XEN_PAGE_SIZE that will be mapped
+ * @param base_pfn - PFN from which memory will be mapped
+ * @param mapped_addr - result pointer for pointer with mapped memory
+ *
+ * @return - zero on success, negative errno on failure
+ */
+int xenmem_map_region(int domid, uint64_t nr_pages,
+		      xen_pfn_t base_pfn, void **mapped_addr);
+
+/*
+ * Unmaps previously mapped quest memory by xenmem_map_region from Dom0.
+ *
+ * @param nr_pages - number of pages with XEN_PAGE_SIZE that will be unmapped
+ * @param mapped_addr - pointer to memory which will be unmapped
+ *
+ * @return - zero on success, negative errno on failure
+ */
+int xenmem_unmap_region(uint64_t nr_pages, void *mapped_addr);
+
+/*
+ * Flushes PFNs mapped to Dom0
+ *
+ * @param nr_pages - number of pages with XEN_PAGE_SIZE for which
+ * cache will be flushed
+ * @param base_pfn - PFN from which cache will be flushed
+ *
+ * @return - zero on success, negative errno on failure
+ */
+int xenmem_cacheflush_mapped_pfns(uint64_t nr_pages, uint64_t base_pfn);
+
+/*
+ * Helper function to populate PFNs for given @domid.
+ * Unlike standard xendom_populate_physmap this function
+ * doesn't require passing array as one of the parameters,
+ * so it helps to avoid using VLA or dynamic memory.
+ *
+ * @param domid - domain ID for which memory should be populated
+ * @param base_pfn - PFN from which memory will be populated
+ * @param pfn_shift - the order of PFNs that will be populated.
+ * Acceptable values are: @PFN_4K_SHIFT, @PFN_2M_SHIFT or @PFN_1G_SHIFT
+ * @nr_pages - number of pages with XEN_PAGE_SIZE that will be populated
+ *
+ * @return - number of pages that were successfully populated
+ */
+uint64_t xenmem_populate_physmap(int domid,
+				 uint64_t base_pfn,
+				 uint64_t pfn_shift,
+				 uint64_t nr_pages);
+
+#endif

--- a/xen-dom-mgmt/src/mem-mgmt.c
+++ b/xen-dom-mgmt/src/mem-mgmt.c
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (c) 2023 EPAM Systems
+ */
+
+#include <zephyr/xen/dom0/domctl.h>
+#include <zephyr/xen/memory.h>
+#include <zephyr/logging/log.h>
+
+#include "mem-mgmt.h"
+
+LOG_MODULE_DECLARE(xen_dom_mgmt);
+
+static uint64_t xendom_add_to_physmap_batch_by_chunks(int domid,
+						      uint64_t base_pfn,
+						      uint64_t base_gfn,
+						      uint64_t nr_pages)
+{
+	int rc;
+	uint64_t i = 0;
+	uint64_t gfns[CONFIG_PFN_CHUNK_SIZE];
+	uint64_t pfns[CONFIG_PFN_CHUNK_SIZE];
+	int err_codes[CONFIG_PFN_CHUNK_SIZE];
+	int j, iter;
+
+	while (i < nr_pages) {
+		iter = MIN(nr_pages - i, CONFIG_PFN_CHUNK_SIZE);
+
+		for (j = 0; j < iter; j++) {
+			pfns[j] = base_pfn + j;
+			gfns[j] = base_gfn + j;
+		}
+
+		rc = xendom_add_to_physmap_batch(DOMID_SELF, domid,
+						 XENMAPSPACE_gmfn_foreign,
+						 iter, gfns,
+						 pfns, err_codes);
+		if (rc < 0) {
+			LOG_ERR("Failed to add to physmap batch for domain#%u (rc=%d)",
+				domid, rc);
+			return i;
+		}
+
+		/* Check error codes for every page frame */
+		for (j = 0; j < iter; j++) {
+			if (err_codes[j]) {
+				/*
+				 * Return the last successfully added
+				 * PFN number.
+				 */
+				if (!i) {
+					return 0;
+				}
+				return (i - 1);
+			}
+			i++;
+		}
+		base_pfn += iter;
+		base_gfn += iter;
+	}
+
+	return i;
+}
+
+uint64_t xenmem_populate_physmap(int domid,
+				 uint64_t base_pfn,
+				 uint64_t pfn_shift,
+				 uint64_t nr_pages)
+{
+	uint64_t i = 0, j;
+	uint64_t pfns[CONFIG_PFN_CHUNK_SIZE];
+	unsigned int populate_iter;
+	int ret;
+
+	while (i < nr_pages) {
+		populate_iter = MIN(nr_pages - i, CONFIG_PFN_CHUNK_SIZE);
+
+		for (j = 0; j < populate_iter; j++) {
+			pfns[j] = base_pfn + (j << pfn_shift);
+		}
+
+		ret = xendom_populate_physmap(domid, pfn_shift, populate_iter,
+					      0, pfns);
+		i += ret;
+		if (ret != populate_iter) {
+			LOG_ERR("Failed to populate physmap (rc=%d)", ret);
+			return i;
+		}
+		base_pfn += (populate_iter << pfn_shift);
+	}
+
+	return i;
+}
+
+int xenmem_map_region(int domid, uint64_t nr_pages,
+		      uint64_t base_gfn, void **mapped_addr)
+{
+	uint64_t nr_added_pfns, nr_pfn_removed, base_pfn, i, populated_pfns;
+	int rc = -ENOMEM;
+
+	if (!mapped_addr) {
+		return -EINVAL;
+	}
+
+	*mapped_addr = k_aligned_alloc(XEN_PAGE_SIZE,
+				       XEN_PAGE_SIZE * nr_pages);
+	if (!*mapped_addr) {
+		LOG_ERR("Failed to alloc memory for mapping");
+		return -ENOMEM;
+	}
+
+	base_pfn = xen_virt_to_gfn(*mapped_addr);
+	for (i = 0, nr_pfn_removed = 0; i < nr_pages; i++, nr_pfn_removed++) {
+		rc = xendom_remove_from_physmap(DOMID_SELF, base_pfn + i);
+		if (rc < 0) {
+			LOG_ERR("Failed to remove PFN#%llu (0x%llx) from physmap (rc=%d)",
+				i, base_pfn + i, rc);
+			/*
+			 * We failed at the first iteration,
+			 * so just free memory
+			 */
+			if (!nr_pfn_removed)
+				goto err_out;
+			goto pfn_remove_err;
+		}
+	}
+
+	nr_added_pfns = xendom_add_to_physmap_batch_by_chunks(domid,
+							      base_pfn,
+							      base_gfn,
+							      nr_pages);
+	if (nr_added_pfns != nr_pages) {
+		goto gfn_add_err;
+	}
+
+	return 0;
+
+gfn_add_err:
+	for (i = 0; i < nr_added_pfns; i++) {
+		rc = xendom_remove_from_physmap(DOMID_SELF, base_pfn + i);
+		if (rc < 0) {
+			LOG_ERR("Failed to remove PFN#%llu (0x%llx) from physmap while restoring Dom0 physmap (rc=%d)",
+				i, base_pfn + i, rc);
+			return rc;
+		}
+	}
+
+pfn_remove_err:
+	populated_pfns = xenmem_populate_physmap(DOMID_SELF, base_pfn,
+						 PFN_4K_SHIFT, nr_pfn_removed);
+	if (populated_pfns != nr_pfn_removed) {
+		LOG_ERR("Failed to populate physmap while restoring Dom0 physmap (populated only %llu instead of %llu)",
+			populated_pfns, nr_pfn_removed);
+		return -EFAULT;
+	}
+
+err_out:
+	k_free(*mapped_addr);
+
+	return rc;
+}
+
+int xenmem_unmap_region(uint64_t nr_pages, void *mapped_addr)
+{
+	uint64_t base_pfn, populated_pfns, i;
+	int rc;
+
+	base_pfn = xen_virt_to_gfn(mapped_addr);
+	/* Needed to remove mapped DomU pages from Dom0 physmap */
+	for (i = 0; i < nr_pages; i++) {
+		rc = xendom_remove_from_physmap(DOMID_SELF, base_pfn + i);
+		if (rc < 0) {
+			LOG_ERR("Failed to remove PFN#%llu (0x%llx) from physmap (rc=%d)",
+				i, base_pfn + i, rc);
+			return rc;
+		}
+	}
+
+	populated_pfns = xenmem_populate_physmap(DOMID_SELF, base_pfn,
+						 PFN_4K_SHIFT, nr_pages);
+	if (populated_pfns != nr_pages) {
+		LOG_ERR("Failed to populate physmap (populated only %llu instead of %llu)",
+			populated_pfns, nr_pages);
+		return -EFAULT;
+	}
+
+	k_free(mapped_addr);
+
+	return 0;
+}
+
+int xenmem_cacheflush_mapped_pfns(uint64_t nr_pages, uint64_t base_pfn)
+{
+	struct xen_domctl_cacheflush cacheflush;
+	int rc;
+
+	cacheflush.start_pfn = base_pfn;
+	cacheflush.nr_pfns = nr_pages;
+	rc = xen_domctl_cacheflush(0, &cacheflush);
+	if (rc) {
+		LOG_ERR("Failed to flush cache for PFN [%llx-%llx] (rc=%d)",
+			base_pfn, base_pfn + nr_pages, rc);
+	}
+
+	return rc;
+}


### PR DESCRIPTION
This patch contains implementation of several functions to simplify trivial operations for mapping, unmapping and etc memory operations for guest to Dom0. The functions help caller to avoid VLA or dynamic memory allocations as parameters for standard functions, introduce safer error handling, and try to restore memory in case of some issues.