### PR TITLE
xen-dom-mgmt: make DOM_MAX as a config

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -57,3 +57,10 @@ config PFN_CHUNK_SIZE
 	help
 	  Chunk size for helper functions for mapping/unmapping
 	  memory from guest domain to Dom0.
+
+config DOM_MAX
+	int "Maximum number of DomU"
+	default 4
+	range 1 32
+	help
+	  Maximum number of DomU that can be created and launched.

--- a/xen-console-srv/src/xen_console.c
+++ b/xen-console-srv/src/xen_console.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(xen_domain_console);
 
 #define ESCAPE_CHARACTER		0x1d /* CTR+] */
 
-static K_THREAD_STACK_ARRAY_DEFINE(read_thrd_stack, DOM_MAX,
+static K_THREAD_STACK_ARRAY_DEFINE(read_thrd_stack, CONFIG_DOM_MAX,
 				   XEN_CONSOLE_STACK_SIZE);
 static K_THREAD_STACK_DEFINE(display_thrd_stack, XEN_CONSOLE_STACK_SIZE);
 
@@ -44,7 +44,7 @@ static K_MUTEX_DEFINE(global_console_lock);
 /* There we store pointer to an attached console */
 static struct xen_domain_console *current_console;
 
-BUILD_ASSERT(sizeof(used_threads) * CHAR_BIT >= DOM_MAX);
+BUILD_ASSERT(sizeof(used_threads) * CHAR_BIT >= CONFIG_DOM_MAX);
 BUILD_ASSERT(XEN_CONSOLE_BUFFER_SZ &&
 	     (XEN_CONSOLE_BUFFER_SZ & (XEN_CONSOLE_BUFFER_SZ - 1)) == 0);
 
@@ -72,7 +72,7 @@ static int get_stack_idx(void)
 /* Free allocated stack */
 static void free_stack_idx(int idx)
 {
-	__ASSERT_NO_MSG(idx < DOM_MAX);
+	__ASSERT_NO_MSG(idx < CONFIG_DOM_MAX);
 
 	k_mutex_lock(&global_console_lock, K_FOREVER);
 

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -719,7 +719,7 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 	char *domdtdevs;
 	struct modules_address modules = {0};
 
-	if (dom_num >= DOM_MAX) {
+	if (dom_num >= CONFIG_DOM_MAX) {
 		LOG_ERR("Runtime exceeds maximum number of domains");
 		return -EINVAL;
 	}

--- a/xenstore-srv/include/xenstore_srv.h
+++ b/xenstore-srv/include/xenstore_srv.h
@@ -7,7 +7,6 @@
 #ifndef XENLIB_XENSTORE_SRV_H
 #define XENLIB_XENSTORE_SRV_H
 
-#define DOM_MAX 4
 #define STRING_LENGTH_MAX 128
 
 struct xs_entry {


### PR DESCRIPTION
Currently, DOM_MAX macro is placed in xenstore_srv.h which is confusing, because this define is used in the other not related to xenstore files. This patch converts it to Kconfig option that is more logical and additionally allows changing the maximum number of domains without changing the code.