### PR TITLE
XRUN update parameters due to the integration results

### DIFF
--- a/xrun/src/xrun.c
+++ b/xrun/src/xrun.c
@@ -267,12 +267,14 @@ static int fill_domcfg(struct container *container)
 	/* irqs = domd_irqs, */
 	domcfg->nr_irqs = 0;
 	/*
-	 * TODO: We support only GIC_V2 for not because it's
-	 * comatible with both GiC_V2 and GIC_V3.
 	 * Current implementation doesn't support GIC_NATIVE
-	 * parameter.
+	 * parameter. We use the same gic version as is on the system.
 	 */
+#if defined(CONFIG_GIC_V3)
+	domcfg->gic_version = XEN_DOMCTL_CONFIG_GIC_V3;
+#else
 	domcfg->gic_version = XEN_DOMCTL_CONFIG_GIC_V2;
+#endif
 	domcfg->tee_type = XEN_DOMCTL_CONFIG_TEE_NONE;
 
 	/* domcfg->dtdevs = domd_dtdevs, */

--- a/xrun/src/xrun.c
+++ b/xrun/src/xrun.c
@@ -18,8 +18,6 @@
 #include <xen_dom_mgmt.h>
 #include "xrun.h"
 
-#define MAX_STR_SIZE 64
-
 LOG_MODULE_REGISTER(xrun);
 
 #define CONTAINER_NAME_SIZE 64
@@ -70,8 +68,8 @@ struct container {
 	char *cmdline;
 
 	uint64_t domid;
-	char kernel_image[MAX_STR_SIZE];
-	char dt_image[MAX_STR_SIZE];
+	char kernel_image[CONFIG_XRUN_MAX_PATH_SIZE];
+	char dt_image[CONFIG_XRUN_MAX_PATH_SIZE];
 	bool has_dt_image;
 	/* struct domain_spec spec; */
 	struct xen_domain_cfg domcfg;
@@ -457,7 +455,7 @@ int xrun_run(const char *bundle, int console_socket, const char *container_id)
 	}
 
 	ret = snprintf(container->kernel_image,
-		       MAX_STR_SIZE,
+		       CONFIG_XRUN_MAX_PATH_SIZE,
 		       "%s", spec.vm.kernel.path);
 	if (ret < strlen(spec.vm.kernel.path)) {
 		LOG_ERR("Unable to get kernel path, rc = %d", ret);
@@ -468,7 +466,7 @@ int xrun_run(const char *bundle, int console_socket, const char *container_id)
 
 	if (container->has_dt_image) {
 		ret = snprintf(container->dt_image,
-			       MAX_STR_SIZE,
+			       CONFIG_XRUN_MAX_PATH_SIZE,
 			       "%s", spec.vm.hwconfig.devicetree);
 		if (ret < strlen(spec.vm.hwconfig.devicetree)) {
 			LOG_ERR("Unable to get device-tree path, rc = %d", ret);


### PR DESCRIPTION
This MR includes 2 changes:
1) Use correct path size for kernel and dt images, received in runtime spec;
2) Use the same GIC version as on the system. It appears that Spider board do not support compatibility between GIC versions and sends not supported error when trying to start domain with gicv2 on it. That's why using system default.