### PR TITLE
xen_console_srv: make xen console server optional

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -26,14 +26,12 @@ config PARTIAL_DEVICE_TREE_SIZE
 
 config XEN_DOMAIN_MANAGEMENT
 	bool "Enable Xen Domain Management"
-	depends on XEN_CONSOLE_SRV
 	help
 	  Enable domain management library. This library allows you
 	  to create, destroy and manage xen domains.
 
 config XEN_CONSOLE_SRV
 	bool "Enable Xen Console server"
-	default y
 	help
 	  Enable xen console server. It should be included if you
 	  are running Zephyr as Dom0, otherwise any DomU that uses

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -32,7 +32,9 @@
 #include <mem-mgmt.h>
 
 #include <xenstore_srv.h>
+#ifdef CONFIG_XEN_CONSOLE_SRV
 #include <xen_console.h>
+#endif
 #include <xss.h>
 
 LOG_MODULE_REGISTER(xen_dom_mgmt);
@@ -799,12 +801,13 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 		goto domain_free;
 	}
 
-
+#ifdef CONFIG_XEN_CONSOLE_SRV
 	rc = xen_start_domain_console(domain);
 	if (rc) {
 		LOG_ERR("Failed to start domain#%u console (rc=%d)", domid, rc);
 		goto free_domain_stored;
 	}
+#endif
 
 	initialize_xenstore(domid, domcfg, domain);
 
@@ -827,7 +830,9 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 	return rc;
 
 stop_domain_console:
+#ifdef CONFIG_XEN_CONSOLE_SRV
 	xen_stop_domain_console(domain);
+#endif
 free_domain_stored:
 	stop_domain_stored(domain);
 domain_free:
@@ -856,11 +861,13 @@ int domain_destroy(uint32_t domid)
 		err = rc;
 	}
 
+#ifdef CONFIG_XEN_CONSOLE_SRV
 	rc = xen_stop_domain_console(domain);
 	if (rc) {
 		LOG_ERR("Failed to stop domain#%u console (rc=%d)", domain->domid, rc);
 		err = rc;
 	}
+#endif
 
 	rc = xen_domctl_destroydomain(domid);
 	if (rc) {

--- a/xen-shell-cmd/src/xen_cmds.c
+++ b/xen-shell-cmd/src/xen_cmds.c
@@ -9,7 +9,9 @@
 #include <stdlib.h>
 
 #include <xen_dom_mgmt.h>
+#ifdef CONFIG_XEN_CONSOLE_SRV
 #include <xen_console.h>
+#endif
 
 LOG_MODULE_REGISTER(xen_shell);
 
@@ -65,6 +67,7 @@ int domu_destroy(const struct shell *shell, size_t argc, char **argv)
 	return domain_destroy(domid);
 }
 
+#ifdef CONFIG_XEN_CONSOLE_SRV
 int domu_console_attach(const struct shell *shell, size_t argc, char **argv)
 {
 	uint32_t domid = 0;
@@ -88,6 +91,7 @@ int domu_console_attach(const struct shell *shell, size_t argc, char **argv)
 
 	return xen_attach_domain_console(shell, domain);
 }
+#endif
 
 int domu_pause(const struct shell *shell, size_t argc, char **argv)
 {


### PR DESCRIPTION
PV console is actually an optional feature. It can be disabled if user is completely sure that DomUs will never use it, or if all DomUs can handle console ring buffer overrun. So, it is strictly advised to enable it, but we need to give user an ability to disable it.

Thus, make all xen_console dependencies optional, remove dependency on XEN_CONSOLE_SRV from XEN_DOMAIN_MANAGEMENT and remove "default y".

Suggested-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>