### PR TITLE
Kconfig: add SHELL selection for XEN_SHELL config

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -41,6 +41,7 @@ config XEN_CONSOLE_SRV
 
 config XEN_SHELL
 	bool "Enable Xen shell commands"
+	select SHELL
 	help
 	  Enable set of Xen shell commands for domain management.
 


### PR DESCRIPTION
Previously, there was and error during builds for samples, that have not enable SHELL option during build. XEN_SHELL module used Zephyr shell infrastructure, but had no dependency to it. Now it will be selected in case user wants to use shell cmds for Xen domain managment.