### PR TITLE
Fix xss_remove and xss_do_write functions

### DIFF
--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -627,8 +627,14 @@ pentry_fail:
 
 int xss_write(const char *path, const char *value)
 {
-	int rc = xss_do_write(path, value);
+	int rc;
 
+	if (!path || !value) {
+		LOG_ERR("Invalid arguments: path or value is NULL");
+		return -EINVAL;
+	}
+
+	rc = xss_do_write(path, value);
 	if (rc) {
 		LOG_ERR("Failed to write to xenstore (rc=%d)", rc);
 	} else {

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -1205,7 +1205,8 @@ static void xenstore_evt_thrd(void *p1, void *p2, void *p3)
 			sz += delta;
 		} while (sz < header->len);
 
-		if (message_handle_list[header->type].h == NULL) {
+		if (header->type >= XS_TYPE_COUNT ||
+		    message_handle_list[header->type].h == NULL) {
 			LOG_ERR("Unsupported message type: %u", header->type);
 			send_errno(domain, header->req_id, ENOSYS);
 		} else {

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -462,7 +462,7 @@ static int xss_do_write(const char *const_path, const char *data)
 	int rc = 0;
 	struct xs_entry *iter = NULL;
 	char *path;
-	char *tok, *tok_state;
+	char *tok, *tok_state, *new_value;
 	size_t data_len = str_byte_size(data);
 	size_t namelen;
 	sys_dlist_t *inspected_list;
@@ -512,16 +512,18 @@ static int xss_do_write(const char *const_path, const char *data)
 	}
 
 	if (iter && data_len > 0) {
-		if (iter->value != NULL) {
-			k_free(iter->value);
-		}
-
-		iter->value = k_malloc(data_len);
-		if (!iter->value) {
+		new_value = k_malloc(data_len);
+		if (!new_value) {
 			LOG_ERR("Failed to allocate memory for xs entry value");
 			rc = -ENOMEM;
 			goto out;
 		}
+
+		if (iter->value) {
+			k_free(iter->value);
+		}
+
+		iter->value = new_value;
 		memcpy(iter->value, data, data_len);
 	}
 


### PR DESCRIPTION
The PR fixes 3 issues:
1) xss_remove behaves incorrectly in case of passing path without any child and leads to an error;
2) xss_do_write in case of memory allocation for value is failure drops the previous value;
3) If xss_do_write is failed in the node allocation loop, it doesn't free already allocated nodes;

Also, removed a redundant check that doesn't ever fire.