### PR TITLE
xenstore-srv: implement buffered read/write

### DIFF
--- a/xen-dom-mgmt/include/domain.h
+++ b/xen-dom-mgmt/include/domain.h
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <zephyr/xen/events.h>
 #include <zephyr/xen/generic.h>
+#include <xenstore_srv.h>
 
 struct xen_domain_iomem {
 	/* where to map, if 0 - map to same place as mfn */
@@ -101,26 +102,14 @@ struct xen_domain_console {
 
 struct xen_domain {
 	uint32_t domid;
-	struct xenstore_domain_interface *domint;
+	struct xenstore xenstore;
 	int num_vcpus;
 	int address_size;
 	uint64_t max_mem_kb;
 	sys_dnode_t node;
-	size_t xs_stack_slot;
 
 	/* TODO: domains can have more than one console */
 	struct xen_domain_console console;
-	struct k_sem xb_sem;
-	struct k_thread xenstore_thrd;
-	atomic_t xenstore_thrd_stop;
-	k_tid_t xenstore_tid;
-	evtchn_port_t xenstore_evtchn;
-	evtchn_port_t local_xenstore_evtchn;
-
-	int transaction;
-	int running_transaction;
-	int stop_transaction_id;
-	bool pending_stop_transaction;
 };
 
 struct xen_domain *domid_to_domain(uint32_t domid);

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -106,10 +106,10 @@ static int allocate_domain_evtchns(struct xen_domain *domain)
 		       rc);
 		return rc;
 	}
-	domain->xenstore_evtchn = rc;
+	domain->xenstore.remote_evtchn = rc;
 
-	LOG_DBG("Generated remote_domid=%d, xenstore_evtchn = %d", domain->domid,
-	       domain->xenstore_evtchn);
+	LOG_DBG("Generated remote_domid=%d, remote_evtchn = %d", domain->domid,
+		domain->xenstore.remote_evtchn);
 
 	rc = alloc_unbound_event_channel_dom0(domain->domid, 0);
 	if (rc < 0) {

--- a/xenstore-srv/include/xenstore_srv.h
+++ b/xenstore-srv/include/xenstore_srv.h
@@ -7,6 +7,21 @@
 #ifndef XENLIB_XENSTORE_SRV_H
 #define XENLIB_XENSTORE_SRV_H
 
+struct xenstore {
+	struct xenstore_domain_interface *domint;
+	struct xen_domain *domain;
+	struct k_sem xb_sem;
+	struct k_thread thrd;
+	atomic_t thrd_stop;
+	evtchn_port_t remote_evtchn;
+	evtchn_port_t local_evtchn;
+	size_t xs_stack_slot;
+	int transaction;
+	int running_transaction;
+	int stop_transaction_id;
+	bool pending_stop_transaction;
+};
+
 int start_domain_stored(struct xen_domain *domain);
 int stop_domain_stored(struct xen_domain *domain);
 

--- a/xenstore-srv/include/xenstore_srv.h
+++ b/xenstore-srv/include/xenstore_srv.h
@@ -7,7 +7,23 @@
 #ifndef XENLIB_XENSTORE_SRV_H
 #define XENLIB_XENSTORE_SRV_H
 
+#include <zephyr/xen/public/io/xs_wire.h>
+
+struct buffered_data {
+	/* Used to link buffers into singly-linked list */
+	sys_snode_t node;
+	/* The number of bytes that was processed for read/write */
+	size_t used;
+	/* The total size of message header and payload */
+	size_t total_size;
+	/* Buffer with header and payload */
+	uint8_t *buffer;
+};
+
 struct xenstore {
+	sys_slist_t out_list;
+	/* Count the number of used out buffers to prevent Denial of Service attacks */
+	int used_out_bufs;
 	struct xenstore_domain_interface *domint;
 	struct xen_domain *domain;
 	struct k_sem xb_sem;

--- a/xenstore-srv/include/xenstore_srv.h
+++ b/xenstore-srv/include/xenstore_srv.h
@@ -22,6 +22,7 @@ struct buffered_data {
 
 struct xenstore {
 	sys_slist_t out_list;
+	struct buffered_data *in;
 	/* Count the number of used out buffers to prevent Denial of Service attacks */
 	int used_out_bufs;
 	struct xenstore_domain_interface *domint;


### PR DESCRIPTION
Current implementation has a few issues such as:
1) In the case of the response buffer is overflowed due to malicious DumU (e.g. performs write operations but does not read responses), the response buffer will be corrupted because of the wrong condition. On the other hand, with the correct condition, overflowing response buffer will lead to infinite loop with trying to write zero-length data;
2) Fixed missing memory barriers in read/write operations;
3) Fixed reading/writing buffers of more than 1KB (size of ring buffers), because according to xenstore specification, it should be able to operate with buffers up to 4KB;

The PR fixes these issues.