### PR TITLE
Implement xenstore permissions

### DIFF
--- a/vch/src/vch.c
+++ b/vch/src/vch.c
@@ -197,12 +197,7 @@ int vch_open(domid_t domain, const char *path, size_t min_rs, size_t min_ws,
 	 * With current code it is possible that it will see only ring-ref
 	 * because event-channel is not yet ready.
 	 */
-	rc = xss_write(xs_key_scratch, xs_val_scratch);
-	if (rc) {
-		goto free_gnt;
-	}
-
-	rc = xss_set_perm(xs_key_scratch, domain, XS_PERM_READ);
+	rc = xss_write_guest_domain_ro(xs_key_scratch, xs_val_scratch, domain);
 	if (rc) {
 		goto free_gnt;
 	}
@@ -210,12 +205,7 @@ int vch_open(domid_t domain, const char *path, size_t min_rs, size_t min_ws,
 	snprintf(xs_key_scratch, sizeof(xs_key_scratch),
 		 "%s/event-channel", h->path);
 	snprintf(xs_val_scratch, sizeof(xs_val_scratch), "%u", h->evtch);
-	rc = xss_write(xs_key_scratch, xs_val_scratch);
-	if (rc) {
-		goto free_gnt;
-	}
-
-	rc = xss_set_perm(xs_key_scratch, domain, XS_PERM_READ);
+	rc = xss_write_guest_domain_ro(xs_key_scratch, xs_val_scratch, domain);
 	if (rc) {
 		goto free_gnt;
 	}

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -664,8 +664,6 @@ static void initialize_xenstore(uint32_t domid,
 	// TODO: generate properly
 	snprintf(uuid, INIT_XENSTORE_UUID_BUF_SIZE, "00000000-0000-0000-0000-%012d", domid);
 
-	xss_write("/tool/xenstored", "");
-
 	for (int i = 0; i < domcfg->max_vcpus; ++i) {
 		sprintf(lbuffer, "%s/%d/cpu/%d/availability", basepref, domid, i);
 		xss_write(lbuffer, "online");
@@ -758,6 +756,7 @@ static int initialize_dom0_xenstore(__attribute__ ((unused)) const struct device
 	dom0cfg->mem_kb = 0;
 	dom0->max_mem_kb = 0;
 #endif
+	xss_write("/tool/xenstored", "");
 	initialize_xenstore(0, dom0cfg, dom0);
 out:
 #ifdef CONFIG_XSTAT

--- a/xenstore-srv/include/xss.h
+++ b/xenstore-srv/include/xss.h
@@ -35,6 +35,24 @@ int xss_read(const char *path, char *value, size_t len);
 int xss_write(const char *path, const char *value);
 
 /*
+ * Associates a value with a path and set read-write permissions for given domid.
+ *
+ * @param path Xenstore path
+ * @param value Xenstore value
+ * @return 0 on success, a negative errno value on error.
+ */
+int xss_write_guest_domain_rw(const char *path, const char *value, uint32_t domid);
+
+/*
+ * Associates a value with a path and set read-only permissions for given domid.
+ *
+ * @param path Xenstore path
+ * @param value Xenstore value
+ * @return 0 on success, a negative errno value on error.
+ */
+int xss_write_guest_domain_ro(const char *path, const char *value, uint32_t domid);
+
+/*
  * Read path and parse it as an integer.
  *
  * @param path Xenstore path

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -36,6 +36,8 @@ LOG_MODULE_REGISTER(xenstore);
  * while domain is not reading responses.
  */
 #define XENSTORE_MAX_OUT_BUF_NUM 10
+#define INIT_XENSTORE_BUFF_SIZE 80
+#define INIT_XENSTORE_UUID_BUF_SIZE 40
 
 struct xs_permissions {
 	sys_snode_t node;


### PR DESCRIPTION
This PR mainly introduces of xenstore permissions feature. The feature is needed to allow or deny access between domains to process some operations with xenstore entries. In additionally to permissions support, also implemented the following:
1) Removing of entries that were created for domain or by domain in case of destruction;
2) Helper functions to create entries and set permission in one action;
3) Moved `initialize_xenstore` function to appropriate place;
4) Minor fix: /tool/xenstored was created every time on domain creation, that is not correct.

**Please note**, that the exact checking permissions were implemented in the last commit in order not to make one large commit and save code consistency between commits.