### PR TITLE
xen-dom-mgmt: add ext memory regions stage 1 map and unmap

### DIFF
--- a/xen-dom-mgmt/src/mem-mgmt.c
+++ b/xen-dom-mgmt/src/mem-mgmt.c
@@ -219,6 +219,10 @@ int xenmem_map_region(int domid, uint64_t nr_pages, uint64_t base_gfn,
 		goto err_out;
 	}
 
+#if defined(CONFIG_XEN_REGIONS)
+	xen_region_map(*mapped_addr, nr_pages);
+#endif
+
 	return 0;
 
 err_out:
@@ -255,6 +259,8 @@ int xenmem_unmap_region(uint64_t nr_pages, void *mapped_addr)
 		LOG_ERR("Failed to populate space, addr: %p", mapped_addr);
 		return -EFAULT;
 	}
+#else
+	xen_region_unmap(mapped_addr, nr_pages);
 #endif
 	return put_region_space(mapped_addr, nr_pages);
 }


### PR DESCRIPTION
Add stage 1 mapping after stage 2 mapping, i.e. after add to phys map. We need it because memory mapping of ext regions has been deleted from xen regions drivers and we need to perform mapping right after add to phys map.

Related pull for zephyr: https://github.com/xen-troops/zephyr/pull/56.