### PR TITLE
xenstore-srv: fix potential security issue while sending errno

### DIFF
--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -492,7 +492,6 @@ static void send_reply_read(struct xenstore *xenstore, uint32_t id,
 static void send_errno(struct xenstore *xenstore, uint32_t id, int err)
 {
 	unsigned int i;
-	LOG_ERR("Sending error=%d", err);
 
 	for (i = 0; err != xsd_errors[i].errnum; i++) {
 		if (i == ARRAY_SIZE(xsd_errors) - 1) {


### PR DESCRIPTION
The send_errno function can be invoked many times from a malicious domain for example by invoking read some xenstore file that does not exist. This will lead to spamming this error message to Dom0 console, that is not safe. Sending just error code to the caller domain is enough to signalize some error that occurred by send_reply.