### PR TITLE
xen-dom-mgmt: domU isn't able to load without passthrough node

### DIFF
--- a/xen-dom-mgmt/src/xen-dom-fdt.c
+++ b/xen-dom-mgmt/src/xen-dom-fdt.c
@@ -771,7 +771,7 @@ static int copy_pfdt(void *fdt, void *pfdt)
 	int r;
 
 	r = copy_node_by_path("/passthrough", fdt, pfdt);
-	if (r < 0) {
+	if (r < 0 && r != -FDT_ERR_NOTFOUND) {
 		LOG_ERR("Can't copy the node \"/passthrough\"");
 		return r;
 	}


### PR DESCRIPTION
Some of DomU may have empty or deleted passthrough node, but 'copy_node_by_path' doesn't handle it.