### PR TITLE
xen_cmds: use DomU config in case of creating user domain

### DIFF
--- a/xen-dom-mgmt/include/xen_dom_mgmt.h
+++ b/xen-dom-mgmt/include/xen_dom_mgmt.h
@@ -19,6 +19,8 @@ int domain_pause(uint32_t domid);
 int domain_unpause(uint32_t domid);
 int domain_post_create(const struct xen_domain_cfg *domcfg, uint32_t domid);
 
+int find_cfg_and_create_domu(uint32_t domid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/xen-shell-cmd/src/xen_cmds.c
+++ b/xen-shell-cmd/src/xen_cmds.c
@@ -45,10 +45,11 @@ static int domu_create(const struct shell *shell, int argc, char **argv)
 		LOG_ERR("Invalid domid passed to create cmd");
 		return -EINVAL;
 	}
-	/*
-	 * TODO: this should be changed in app code.
-	 * Not all domains using domd config
-	 */
+
+	if (domid != 1) {
+		return find_cfg_and_create_domu(domid);
+	}
+
 	ret = domain_create(&domd_cfg, domid);
 	if (ret) {
 		return ret; /* domain_create should care about error logs */


### PR DESCRIPTION
Use DomU config instead of DomD for creating domains with domid higher 1.

### Related PR: https://github.com/aoscloud/aos_core_zephyr/pull/138