### PR TITLE
xen-dom-xs: xstat: add missing xstat header to xen-dom-xs

### DIFF
--- a/xen-dom-mgmt/src/xen-dom-xs.c
+++ b/xen-dom-mgmt/src/xen-dom-xs.c
@@ -16,6 +16,7 @@
 #include <domain.h>
 #include <xen/public/io/xs_wire.h>
 #include <xss.h>
+#include <xstat.h>
 #include <xen-dom-xs.h>
 #include <xenstore_srv.h>
 


### PR DESCRIPTION
Enabling of CONFIG_XSTAT generated build warnings due to implicit functions and incomplete types related to xstat.
Add missing header to xen-dom-xs source file.
