### PR TITLE
HOTFIX: xenstore-cmd: Fix xs_ls command

### DIFF
--- a/xen-shell-cmd/src/xenstore_cmds.c
+++ b/xen-shell-cmd/src/xenstore_cmds.c
@@ -57,7 +57,7 @@ static int xs_ls(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	paths = xss_directory(argv[1], &len);
+	paths = xss_list_entries(argv[1], &len);
 
 	if (!paths) {
 		shell_error(shell, "Failed to list xenstore path %s", argv[1]);


### PR DESCRIPTION
During refactoring rename of xss_directory to xss_list_entries, one occurrence was missed. This patch fixes it.