### PR TITLE
xen-dom-mgmt: dom0: add dom0 initcall routine

### DIFF
--- a/xenstore-srv/include/xenstore_srv.h
+++ b/xenstore-srv/include/xenstore_srv.h
@@ -45,6 +45,7 @@ struct xenstore {
 
 int start_domain_stored(struct xen_domain *domain);
 int stop_domain_stored(struct xen_domain *domain);
+int xs_init_root(void);
 
 #ifdef __cplusplus
 }

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -2112,9 +2112,8 @@ int stop_domain_stored(struct xen_domain *domain)
 	return err;
 }
 
-static int xs_init_root(const struct device *d)
+int xs_init_root(void)
 {
-	ARG_UNUSED(d);
 	struct xs_permissions permissions = {
 		.domid = 0,
 		.perms = XS_PERM_NONE,
@@ -2127,4 +2126,3 @@ static int xs_init_root(const struct device *d)
 	return 0;
 }
 
-SYS_INIT(xs_init_root, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
During Zephyr xenlib initialization some actions (root node init in Xenstore, Domain-0 Xenstore entries adding) should be done right before application start. Previously these actions were implemented in separate initcalls with different priorities which is a little bit complicated.

As we will need to have Domain-0 struct in runtime soon (for further implementation of xss watch functions in Xenstore API), Domain-0 related actions were moved to single routine: root node init was made global and xenstore entries adding was refatored. So now we can simplify priorities for initcalls and have a single place where all pre-application actions can be done.