### PR TITLE
xrun: Fix test build

### DIFF
--- a/tests/xrun/CMakeLists.txt
+++ b/tests/xrun/CMakeLists.txt
@@ -7,6 +7,6 @@ project(test_xrun)
 target_include_directories(app PRIVATE ${APPLICATION_SOURCE_DIR}/../../xrun/include/
 ${APPLICATION_SOURCE_DIR}/include)
 
-FILE(GLOB app_sources src/main.c src/mock-storage.c src/mock-xen-dom-mgmt.c)
+FILE(GLOB app_sources src/main.c src/mock-storage.c src/mock-xen-dom-mgmt.c src/mock-parser.c)
 target_sources(app PRIVATE ${app_sources} ../../xrun/src/xrun.c)
 zephyr_include_directories(include)

--- a/tests/xrun/include/domain.h
+++ b/tests/xrun/include/domain.h
@@ -29,6 +29,8 @@
 #define _XEN_DOMCTL_CDF_hap           1
 #define XEN_DOMCTL_CDF_hap            (1U << _XEN_DOMCTL_CDF_hap)
 
+#define CONTAINER_NAME_SIZE 64
+
 struct xen_domain_iomem {
 	/* where to map, if 0 - map to same place as mfn */
 	uint64_t first_gfn;
@@ -57,7 +59,22 @@ typedef int (*load_image_bytes_t)(uint8_t *buf, size_t bufsize,
  */
 typedef ssize_t (*get_image_size_t)(void *image_info, uint64_t *size);
 
+struct pv_net_configuration {
+};
+
+struct pv_block_configuration {
+};
+
+#define MAX_PV_NET_DEVICES 3
+#define MAX_PV_BLOCK_DEVICES 3
+
+struct backend_configuration {
+	struct pv_net_configuration vifs[MAX_PV_NET_DEVICES];
+	struct pv_block_configuration disks[MAX_PV_BLOCK_DEVICES];
+};
+
 struct xen_domain_cfg {
+	char name[CONTAINER_NAME_SIZE];
 	uint64_t mem_kb;
 
 	uint32_t flags;
@@ -91,6 +108,7 @@ struct xen_domain_cfg {
 	get_image_size_t get_image_size;
 
 	void *image_info;
+	struct backend_configuration back_cfg;
 };
 
 struct xen_domain_console {

--- a/tests/xrun/include/xen_dom_mgmt.h
+++ b/tests/xrun/include/xen_dom_mgmt.h
@@ -13,5 +13,6 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid);
 int domain_destroy(uint32_t domid);
 int domain_pause(uint32_t domid);
 int domain_unpause(uint32_t domid);
+int domain_post_create(const struct xen_domain_cfg *domcfg, uint32_t domid);
 
 #endif

--- a/tests/xrun/include/xl_parser.h
+++ b/tests/xrun/include/xl_parser.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef XL_PARSER_H
+#define XL_PARSER_H
+
+#include <domain.h>
+
+/**
+ * Function that takes one xl-like(see https://xenbits.xen.org/docs/unstable/man/xl.cfg.5.html Devices chapter)
+ * and fill appropriate unconfigured parts inside cfg.
+ * Note: currently supported configuration types are:
+ *       disk https://xenbits.xen.org/docs/unstable/man/xl-disk-configuration.5.html
+ *       vif  https://xenbits.xen.org/docs/unstable/man/xl-network-configuration.5.html
+ * Examples:
+ *  disk=['backend=1, vdev=xvda, access=rw, target=/dev/mmcblk0p3']
+ *  vif =['backend=1,bridge=xenbr0,mac=08:00:27:ff:cb:ce,ip=172.44.0.2 255.255.255.0 172.44.0.1']
+ *
+ * Note: all internal configurations should obey key=value scheme.
+ *
+ * Restriction on disk type: only Xen virtual disk (aka xvd without partitions and in
+ * lowercase) supported.
+ * see : https://xenbits.xen.org/docs/unstable/man/xen-vbd-interface.7.html
+ *
+ * @param str xl like backend configuration string
+ * @param cfg pointer to global backends configuration structure
+ * @return 0 on success, negative errno on error
+ */
+int parse_one_record_and_fill_cfg(const char *str, struct backend_configuration *cfg);
+
+#endif /* XL_PARSER_H */

--- a/tests/xrun/src/mock-parser.c
+++ b/tests/xrun/src/mock-parser.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2024 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <xl_parser.h>
+
+int parse_one_record_and_fill_cfg(const char *str, struct backend_configuration *cfg)
+{
+	return 0;
+}

--- a/tests/xrun/src/mock-xen-dom-mgmt.c
+++ b/tests/xrun/src/mock-xen-dom-mgmt.c
@@ -33,3 +33,8 @@ int domain_unpause(uint32_t domid)
 {
 	return 0;
 }
+
+int domain_post_create(const struct xen_domain_cfg *domcfg, uint32_t domid)
+{
+	return 0;
+}


### PR DESCRIPTION
xenlib has changed a bit and test build is broken now. This patch updates mocks to fix this.