### PR TITLE
xen-dom-mgmt: Fix potential concurrency issues

### DIFF
--- a/tests/xrun/include/domain.h
+++ b/tests/xrun/include/domain.h
@@ -117,6 +117,7 @@ struct xen_domain_console {
 struct xen_domain {
 };
 
-struct xen_domain *domid_to_domain(uint32_t domid);
+struct xen_domain *get_domain(uint32_t domid);
+void put_domain(struct xen_domain *domain);
 
 #endif /* XENLIB_XEN_DOMAIN_H */

--- a/xen-console-srv/src/xen_console.c
+++ b/xen-console-srv/src/xen_console.c
@@ -480,6 +480,7 @@ int xen_attach_domain_console(const struct shell *shell,
 		/* Actually, this should never happen */
 		shell_error(shell, "Shell is already attached to console");
 		k_mutex_unlock(&global_console_lock);
+		put_domain(domain);
 		return -EEXIST;
 	}
 	current_console = console;
@@ -500,6 +501,7 @@ int xen_attach_domain_console(const struct shell *shell,
 
 	shell_set_bypass(shell, console_shell_cb);
 
+	put_domain(domain);
 	return 0;
 }
 

--- a/xen-dom-mgmt/include/domain.h
+++ b/xen-dom-mgmt/include/domain.h
@@ -201,6 +201,7 @@ struct xen_domain {
 	int address_size;
 	uint64_t max_mem_kb;
 	sys_dnode_t node;
+	int refcount;
 
 	/* TODO: domains can have more than one console */
 	struct xen_domain_console console;
@@ -209,7 +210,8 @@ struct xen_domain {
 	bool f_dom0less:1; /**< Indicates that domain was created by Xen itself */
 };
 
-struct xen_domain *domid_to_domain(uint32_t domid);
+struct xen_domain *get_domain(uint32_t domid);
+void put_domain(struct xen_domain *domain);
 
 #ifdef __cplusplus
 }

--- a/xen-dom-mgmt/include/xen-dom-xs.h
+++ b/xen-dom-mgmt/include/xen-dom-xs.h
@@ -27,10 +27,10 @@ int xs_add_pvblock_xenstore(const struct pv_block_configuration *cfg, int domid)
 /**
  * Removes all XenStore backends for a specific domain.
  *
- * @param domid The ID of the domain.
+ * @param domain The Xen domain structure.
  * @return 0 on success, negative error code on failure.
  */
-int xs_remove_xenstore_backends(int domid);
+int xs_remove_xenstore_backends(struct xen_domain *domain);
 
 /**
  * Adds a PV network backend to the XenStore for a specific domain.

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -809,7 +809,7 @@ int domain_destroy(uint32_t domid)
 		return -ENOTSUP;
 	}
 
-	rc = xs_remove_xenstore_backends(domid);
+	rc = xs_remove_xenstore_backends(domain);
 	if (rc) {
 		LOG_ERR("Failed to remove_xenstore_backends domain#%u (rc=%d)", domain->domid, rc);
 		err = rc;

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -579,23 +579,64 @@ static int assign_dtdevs(int domid, char *dtdevs[], int nr_dtdevs)
 	return rc;
 }
 
-/*
- * TODO: Access to domain_list and domains should be protected, considering that it may be
- * destroyed after receiving pointer to actual domain. So all accesses to domains structs should be
- * protected globally or via refcounts. This requires code audit in all libs, that are using this
- * function (currently xenstore-srv and xen_shell).
- */
-struct xen_domain *domid_to_domain(uint32_t domid)
+struct xen_domain *get_domain(uint32_t domid)
 {
 	struct xen_domain *iter;
 
+	k_mutex_lock(&dl_mutex, K_FOREVER);
 	SYS_DLIST_FOR_EACH_CONTAINER (&domain_list, iter, node) {
 		if (iter->domid == domid) {
-			return iter;
+			iter->refcount++;
+			break;
 		}
 	}
+	k_mutex_unlock(&dl_mutex);
+	return iter;
+}
 
-	return NULL;
+void put_domain(struct xen_domain *domain)
+{
+	int rc;
+
+	if (!domain) {
+		LOG_ERR("Domain is NULL");
+		return;
+	}
+	__ASSERT(!domain->f_dom0less, "dom0less domain#%u operation not supported", domain->domid);
+
+	k_mutex_lock(&dl_mutex, K_FOREVER);
+	domain->refcount--;
+	if (domain->refcount == 0) {
+		rc = xs_remove_xenstore_backends(domain);
+		if (rc) {
+			LOG_ERR("Failed to remove_xenstore_backends domain#%u (rc=%d)",
+					domain->domid, rc);
+		}
+
+		rc = stop_domain_stored(domain);
+		if (rc) {
+			LOG_ERR("Failed to stop domain#%u store (rc=%d)", domain->domid, rc);
+		}
+
+		xs_deinitialize_domain_xenstore(domain->domid);
+
+	#ifdef CONFIG_XEN_CONSOLE_SRV
+		rc = xen_stop_domain_console(domain);
+		if (rc) {
+			LOG_ERR("Failed to stop domain#%u console (rc=%d)", domain->domid, rc);
+		}
+	#endif
+
+		rc = xen_domctl_destroydomain(domain->domid);
+		if (rc) {
+			LOG_ERR("Failed to destroy domain#%u (rc=%d)", domain->domid, rc);
+		}
+
+		sys_dlist_remove(&domain->node);
+		--dom_num;
+		k_free(domain);
+	}
+	k_mutex_unlock(&dl_mutex);
 }
 
 struct xen_domain_cfg *domain_find_config(const char *name)
@@ -767,6 +808,7 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 	}
 
 	k_mutex_lock(&dl_mutex, K_FOREVER);
+	domain->refcount = 1;
 	sys_dnode_init(&domain->node);
 	sys_dlist_append(&domain_list, &domain->node);
 	++dom_num;
@@ -794,57 +836,20 @@ destroy_domain:
 
 int domain_destroy(uint32_t domid)
 {
-	int rc, err = 0;
 	struct xen_domain *domain = NULL;
 
-	domain = domid_to_domain(domid);
+	domain = get_domain(domid);
 	if (!domain) {
 		LOG_ERR("Domain with domid#%u is not found", domid);
 		/* Domain with requested domid is not present in list */
 		return -EINVAL;
 	}
 
-	if (domain->f_dom0less) {
-		LOG_ERR("dom0less domain#%u operation not supported", domid);
-		return -ENOTSUP;
-	}
+	/* Call put domain twice to drop the original reference and trigger freeing */
+	put_domain(domain);
+	put_domain(domain);
 
-	rc = xs_remove_xenstore_backends(domain);
-	if (rc) {
-		LOG_ERR("Failed to remove_xenstore_backends domain#%u (rc=%d)", domain->domid, rc);
-		err = rc;
-	}
-
-	rc = stop_domain_stored(domain);
-	if (rc) {
-		LOG_ERR("Failed to stop domain#%u store (rc=%d)", domain->domid, rc);
-		err = rc;
-	}
-
-	xs_deinitialize_domain_xenstore(domid);
-
-#ifdef CONFIG_XEN_CONSOLE_SRV
-	rc = xen_stop_domain_console(domain);
-	if (rc) {
-		LOG_ERR("Failed to stop domain#%u console (rc=%d)", domain->domid, rc);
-		err = rc;
-	}
-#endif
-
-	rc = xen_domctl_destroydomain(domid);
-	if (rc) {
-		LOG_ERR("Failed to destroy domain#%u (rc=%d)", domain->domid, rc);
-		err = rc;
-	}
-
-	k_mutex_lock(&dl_mutex, K_FOREVER);
-	sys_dlist_remove(&domain->node);
-	--dom_num;
-	k_mutex_unlock(&dl_mutex);
-
-	k_free(domain);
-
-	return err;
+	return 0;
 }
 
 int domain_pause(uint32_t domid)
@@ -852,7 +857,7 @@ int domain_pause(uint32_t domid)
 	int rc;
 	struct xen_domain *domain = NULL;
 
-	domain = domid_to_domain(domid);
+	domain = get_domain(domid);
 	if (!domain) {
 		LOG_ERR("Domain with domid#%u is not found", domid);
 		/* Domain with requested domid is not present in list */
@@ -863,6 +868,7 @@ int domain_pause(uint32_t domid)
 	if (rc) {
 		LOG_ERR("domain:%u pause failed (%d)", domid, rc);
 	}
+	put_domain(domain);
 
 	return rc;
 }
@@ -872,7 +878,7 @@ int domain_unpause(uint32_t domid)
 	struct xen_domain *domain = NULL;
 	int rc;
 
-	domain = domid_to_domain(domid);
+	domain = get_domain(domid);
 	if (!domain) {
 		LOG_ERR("Domain with domid#%u is not found", domid);
 		/* Domain with requested domid is not present in list */
@@ -884,6 +890,7 @@ int domain_unpause(uint32_t domid)
 		LOG_ERR("domain:%u unpause failed (%d)", domid, rc);
 	}
 
+	put_domain(domain);
 	return rc;
 }
 
@@ -894,7 +901,7 @@ int domain_post_create(const struct xen_domain_cfg *domcfg, uint32_t domid)
 	struct backends_state *bs = NULL;
 	const struct backend_configuration *bc = NULL;
 
-	domain = domid_to_domain(domid);
+	domain = get_domain(domid);
 	bs = &domain->back_state;
 	bc = &domcfg->back_cfg;
 
@@ -924,9 +931,11 @@ int domain_post_create(const struct xen_domain_cfg *domcfg, uint32_t domid)
 		}
 	}
 
+	put_domain(domain);
 	return 0;
 
 deinit:
+	put_domain(domain);
 	LOG_ERR("Failed to initialize xenstore for domid#%u (rc=%d)", domid, rc);
 	domain_destroy(domid);
 	return rc;

--- a/xen-dom-mgmt/src/xen-dom-xs.c
+++ b/xen-dom-mgmt/src/xen-dom-xs.c
@@ -262,14 +262,11 @@ int xs_add_pvblock_xenstore(const struct pv_block_configuration *cfg, int domid)
 	return 0;
 }
 
-int xs_remove_xenstore_backends(int domid)
+int xs_remove_xenstore_backends(struct xen_domain *domain)
 {
 	char lbuffer[INIT_XENSTORE_BUFF_SIZE] = { 0 };
 	static const char basepref[] = "/local/domain";
 	int rc = 0, i;
-	struct xen_domain *domain = NULL;
-
-	domain = domid_to_domain(domid);
 
 	for (i = 0; i < MAX_PV_NET_DEVICES; i++) {
 		if (domain->back_state.vifs[i].functional) {
@@ -278,7 +275,7 @@ int xs_remove_xenstore_backends(int domid)
 			 * at least one fucntional vif backend.
 			 */
 			sprintf(lbuffer, "%s/%d/backend/vif/%d", basepref,
-				domain->back_state.vifs[i].backend_domain_id, domid);
+				domain->back_state.vifs[i].backend_domain_id, domain->domid);
 			rc = xss_rm(lbuffer);
 			if (rc) {
 				LOG_ERR("Failed to remove node  %s (rc=%d)", lbuffer, rc);
@@ -294,7 +291,7 @@ int xs_remove_xenstore_backends(int domid)
 			 * at least one fucntional vbd backend.
 			 */
 			sprintf(lbuffer, "%s/%d/backend/vbd/%d", basepref,
-				domain->back_state.disks[i].backend_domain_id, domid);
+				domain->back_state.disks[i].backend_domain_id, domain->domid);
 			rc = xss_rm(lbuffer);
 			if (rc) {
 				LOG_ERR("Failed to remove node  %s (rc=%d)", lbuffer, rc);

--- a/xen-shell-cmd/src/xen_cmds.c
+++ b/xen-shell-cmd/src/xen_cmds.c
@@ -186,7 +186,7 @@ int domu_console_attach(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	domain = domid_to_domain(domid);
+	domain = get_domain(domid);
 	if (!domain) {
 		shell_error(shell, "domid#%u is not found", domid);
 		/* Domain with requested domid is not present in list */


### PR DESCRIPTION
Add refcounting to the domain structure to make it thread-safe. Fix possible deadlock in console deinit.