### PR TITLE
Streamline command line interface

### DIFF
--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -632,7 +632,7 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 	memset(&config, 0, sizeof(config));
 	prepare_domain_cfg(domcfg, &config);
 	config.grant_opts = XEN_DOMCTL_GRANT_version(1);
-	rc = xen_domctl_createdomain(domid, &config);
+	rc = xen_domctl_createdomain(&domid, &config);
 	if (rc) {
 		LOG_ERR("Failed to create domain#%u (rc=%d)", domid, rc);
 		return rc;

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -749,7 +749,7 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 			goto stop_domain_console;
 		}
 	} else {
-		LOG_INF("Created domain is paused\nTo unpause issue: xu unpause -d %u", domid);
+		LOG_INF("Created domain is paused\nTo unpause issue: xu unpause %u", domid);
 	}
 
 	k_mutex_lock(&dl_mutex, K_FOREVER);

--- a/xen-shell-cmd/src/xen_cmds.c
+++ b/xen-shell-cmd/src/xen_cmds.c
@@ -20,12 +20,14 @@ extern struct xen_domain_cfg domd_cfg;
 uint32_t parse_domid(size_t argc, char **argv)
 {
 	/* first would be the cmd name, start from second */
-	int pos = 1;
+	int i;
 
-	if (argv[pos][0] == '-' && argv[pos][1] == 'd') {
-		/* Take next value after "-d" option */
-		pos++;
-		return atoi(argv[pos]);
+	for (i = 0; i < argc - 1; i++) {
+		if (argv[i][0] == '-' && argv[i][1] == 'd') {
+			/* Take next value after "-d" option */
+			i++;
+			return atoi(argv[i]);
+		}
 	}
 
 	/* Use zero as invalid value */
@@ -35,15 +37,14 @@ uint32_t parse_domid(size_t argc, char **argv)
 static int domu_create(const struct shell *shell, int argc, char **argv)
 {
 	int ret;
-	uint32_t domid;
+	uint32_t domid = 0;
 
-	if (argc != 3)
-		return -EINVAL;
-
-	domid = parse_domid(argc, argv);
-	if (!domid) {
-		LOG_ERR("Invalid domid passed to create cmd");
-		return -EINVAL;
+	if (argc > 2) {
+		domid = parse_domid(argc, argv);
+		if (!domid) {
+			LOG_ERR("Invalid domid passed to create cmd");
+			return -EINVAL;
+		}
 	}
 	/*
 	 * TODO: this should be changed in app code.
@@ -61,10 +62,10 @@ int domu_destroy(const struct shell *shell, size_t argc, char **argv)
 {
 	uint32_t domid = 0;
 
-	if (argc != 3)
+	if (argc != 2)
 		return -EINVAL;
 
-	domid = parse_domid(argc, argv);
+	domid = atoi(argv[1]);
 	if (!domid) {
 		shell_error(shell, "Invalid domid passed to destroy cmd\n");
 		return -EINVAL;
@@ -79,10 +80,10 @@ int domu_console_attach(const struct shell *shell, size_t argc, char **argv)
 	uint32_t domid = 0;
 	struct xen_domain *domain;
 
-	if (argc != 3)
+	if (argc != 2)
 		return -EINVAL;
 
-	domid = parse_domid(argc, argv);
+	domid = atoi(argv[1]);
 	if (!domid) {
 		shell_error(shell, "Invalid domid passed to create cmd\n");
 		return -EINVAL;
@@ -103,10 +104,10 @@ int domu_pause(const struct shell *shell, size_t argc, char **argv)
 {
 	uint32_t domid = 0;
 
-	if (argc != 3)
+	if (argc != 2)
 		return -EINVAL;
 
-	domid = parse_domid(argc, argv);
+	domid = atoi(argv[1]);
 	if (!domid) {
 		shell_error(shell, "Invalid domid passed to destroy cmd\n");
 		return -EINVAL;
@@ -119,16 +120,14 @@ int domu_unpause(const struct shell *shell, size_t argc, char **argv)
 {
 	uint32_t domid = 0;
 
-	if (argc != 3)
+	if (argc != 2)
 		return -EINVAL;
 
-	domid = parse_domid(argc, argv);
+	domid = atoi(argv[1]);
 	if (!domid) {
 		shell_error(shell, "Invalid domid passed to unpause cmd\n");
 		return -EINVAL;
 	}
-
-	shell_print(shell, "domid=%d\n", domid);
 
 	return domain_unpause(domid);
 }
@@ -137,26 +136,26 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	subcmd_xu,
 	SHELL_CMD_ARG(create, NULL,
 		      " Create Xen domain\n"
-		      " Usage: create -d <domid>\n",
-		      domu_create, 3, 0),
+		      " Usage: create [-d <domid>]\n",
+		      domu_create, 1, 2),
 	SHELL_CMD_ARG(destroy, NULL,
 		      " Destroy Xen domain\n"
-		      " Usage: destroy -d <domid>\n",
-		      domu_destroy, 3, 0),
+		      " Usage: destroy <domid>\n",
+		      domu_destroy, 2, 0),
 	SHELL_CMD_ARG(pause, NULL,
 		      " Pause Xen domain\n"
-		      " Usage: pause -d <domid>\n",
-		      domu_pause, 3, 0),
+		      " Usage: pause <domid>\n",
+		      domu_pause, 2, 0),
 	SHELL_CMD_ARG(unpause, NULL,
 		      " Unpause Xen domain\n"
-		      " Usage: unpause -d <domid>\n",
-		      domu_unpause, 3, 0),
+		      " Usage: unpause <domid>\n",
+		      domu_unpause, 2, 0),
 #ifdef CONFIG_XEN_CONSOLE_SRV
-	SHELL_CMD_ARG(console_attach, NULL,
+	SHELL_CMD_ARG(console, NULL,
 		      " Attach to a domain console.\n"
 		      " Press CTRL+] to detach from console\n"
-		      " Usage: console_attach -d <domid>\n",
-		      domu_console_attach, 3, 0),
+		      " Usage: console <domid>\n",
+		      domu_console_attach, 2, 0),
 #endif
 	SHELL_SUBCMD_SET_END);
 


### PR DESCRIPTION
Fixes https://github.com/xen-troops/zephyr-xenlib/issues/69

Bring command line interface of xu util to a more common form.
Make mandatory arguments positional and allow optional arguments.
Implement automatic domid selection for new domains if not provided.
Simplify console command name.