### PR TITLE
xenstore: rework "xs ls" cmd to dump all entries in a directory recursively 

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -52,6 +52,15 @@ config XENSTORE_SHELL_READ_SIZE
 	help
 	  Sets the maximum size that xs read cmd can handle
 
+config XENSTORE_TREE_TRAVERSE_DEPTH
+	int "Maximum xs traverse depth"
+	default 8
+	range 1 16
+	depends on XEN_SHELL
+	help
+	  Sets the maximum xs traverse depth to avoid stack overflow
+	  in case of deeply nested XS trees.
+
 config XRUN_SHELL_CMDS
 	bool "Enable XRUN shell commands"
 	help

--- a/xenstore-srv/include/xss.h
+++ b/xenstore-srv/include/xss.h
@@ -97,15 +97,6 @@ int xss_set_perm(const char *path, domid_t domid, enum xs_perm perm);
 int xss_rm(const char *path);
 
 /**
- * List all entries in a directory.
- *
- * @param path Xenstore path
- * @param len Number of entries in the directory
- * @return Dynamically allocated array of dynamically allocated strings with directory entries
- */
-char **xss_list_entries(const char *path, int *len);
-
-/**
  * @brief Xenstore traverse callback
  *
  * @param[in] data User data passed in xss_list_traverse()

--- a/xenstore-srv/include/xss.h
+++ b/xenstore-srv/include/xss.h
@@ -105,6 +105,33 @@ int xss_rm(const char *path);
  */
 char **xss_list_entries(const char *path, int *len);
 
+/**
+ * @brief Xenstore traverse callback
+ *
+ * @param[in] data User data passed in xss_list_traverse()
+ * @param[in] key Xenstore entry name
+ * @param[in] value Xenstore entry value, NULL if not set
+ * @param[in] depth Xenstore tree current depth, starting from 0 (root)
+ */
+typedef void (*xss_traverse_callback_t)(void *data, const char *key, const char *value, int depth);
+
+/**
+ * @brief traverse all entries in a directory recursively
+ *
+ * This function traverses all Xenstore entries starting from @p path and calls
+ * user callback @p cb for each entry.
+ *
+ * @param[in] path Xenstore path
+ * @param[in] cb traverse callback
+ * @param[in] data to be passed in @p cb
+ *
+ * @retval 0 If successful
+ * @retval -EINVAL if @cb not provided
+ * @retval -ENOENT if @p path not found
+ */
+int xss_list_traverse(const char *path, xss_traverse_callback_t cb, void *data);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -1145,6 +1145,11 @@ static void xss_list_traverse_entry(struct xs_entry *entry, xss_traverse_callbac
 	cb(data, entry->key, entry->value, depth);
 	depth++;
 
+	if (depth >= CONFIG_XENSTORE_TREE_TRAVERSE_DEPTH) {
+		LOG_DBG("Reached XS max traverse depth %d. skip processing", depth);
+		return;
+	}
+
 	children = &entry->child_list;
 	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(children, iter, next, node) {
 		xss_list_traverse_entry(iter, cb, data, depth);

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -1136,57 +1136,6 @@ int xss_read_integer(const char *path, int *value)
 	return rc;
 }
 
-char **xss_list_entries(const char *path, int *len)
-{
-	char **dirs = NULL;
-	int i;
-	struct xs_entry *entry, *iter, *next;
-	sys_dlist_t *children = NULL;
-
-	*len = 0;
-	k_mutex_lock(&xsel_mutex, K_FOREVER);
-	entry = key_to_entry_check_perm(path, 0, XS_PERM_READ);
-	if (!entry) {
-		k_mutex_unlock(&xsel_mutex);
-		return NULL;
-	}
-
-	children = &entry->child_list;
-
-	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(children, iter, next, node) {
-		*len += 1;
-	}
-
-	dirs = k_malloc(*len * sizeof(char *));
-	if (!dirs) {
-		*len = 0;
-		k_mutex_unlock(&xsel_mutex);
-		return NULL;
-	}
-
-	i = 0;
-	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(children, iter, next, node) {
-		dirs[i] = k_malloc(strlen(iter->key) + 1);
-		if (!dirs[i]) {
-			*len = i;
-			k_mutex_unlock(&xsel_mutex);
-			goto err_free;
-		}
-		strcpy(dirs[i], iter->key);
-		i++;
-	}
-
-	k_mutex_unlock(&xsel_mutex);
-	return dirs;
-err_free:
-	for (i = 0; i < *len; i++) {
-		k_free(dirs[i]);
-	}
-	k_free(dirs);
-	*len = 0;
-	return NULL;
-}
-
 static void xss_list_traverse_entry(struct xs_entry *entry, xss_traverse_callback_t cb, void *data,
 				    int depth)
 {


### PR DESCRIPTION
This series adds new Xenstore xss_list_traverse(0 API which accepts Xenstore *path* and traverse all entries recursively starting from the provided *path*. The callback provided by user is called for each Xenstore entry.

Then this xss_list_traverse() API is used to rework "xs ls" Xenstore shell command, so it can provide now proper and informative result by dumping all Xenstore entries with values recursively.

Full Xenstore dump example:

```
uart:~$ xs ls /
0: root
1:   tool
2:     xenstored = 
1:   local
2:     domain
3:       0
4:         memory
5:           static-max = 0
5:           target = 0
5:           videoram = -1
4:         control = 
5:           platform-feature-multiprocessor-suspend = 1
5:           platform-feature-xs_reset_watches = 1
5:           shutdown = 
5:           feature-poweroff = 
5:           feature-reboot = 
5:           feature-suspend = 
5:           sysrq = 
4:         vm = 00000000-0000-0000-0000-000000000000
4:         name = Domain-0
4:         domid = 0
4:         device
5:           vbd = 
5:           suspend
6:             event-channel = 
4:         data = 
4:         drivers = 
4:         feature = 
4:         attr = 
4:         error =                                            
3:       1                                                        
4:         cpu                                                  
5:           0                                            
6:             availability = online         
4:         memory
5:           static-max = 524560
5:           target = 524560
5:           videoram = -1
4:         control = 
5:           platform-feature-multiprocessor-suspend = 1
5:           platform-feature-xs_reset_watches = 1
5:           shutdown = 
5:           feature-poweroff = 
5:           feature-reboot = 
5:           feature-suspend = 
5:           sysrq = 
4:         vm = 00000000-0000-0000-0000-000000000001
4:         name = zephyr-1
4:         domid = 1
4:         device
5:           vbd = 
5:           suspend
6:             event-channel = 
4:         data = 
4:         drivers = 
4:         feature = 
4:         attr = 
4:         error = 
1:   vm
2:     00000000-0000-0000-0000-000000000000
3:       name = Domain-0
3:       start_time = 0
3:       uuid = 00000000-0000-0000-0000-000000000000
2:     00000000-0000-0000-0000-000000000001
3:       name = zephyr-1
3:       start_time = 0
3:       uuid = 00000000-0000-0000-0000-000000000001
1:   libxl
2:     0
3:       dm-version = qemu_xen_traditional
3:       type = pvh
2:     1
3:       dm-version = qemu_xen_traditional
3:       type = pvh
1:   fuck_in
2:     ring-ref = 32767
2:     event-channel = 2
1:   fuck_out
2:     ring-ref = 32766
2:     event-channel = 3
```

