### PR TITLE
xen-dom-mgmt: add xen dom0less boot support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -145,3 +145,12 @@ config XSTAT_SHELL_CMDS
 	bool "Enable XSTAT shell commands"
 	help
 	  Enable set of XSTAT shell commands.
+
+config XEN_DOM0LESS_BOOT
+	bool "Xen dom0less boot support [EXPERIMENTAL]"
+	help
+	  Enable to support Xen dom0less boot. The domains started by Xen
+	  will be identified and added to xenlib domain management subsystem, for each domain
+	  xenstore will be initialized.
+
+	  This is EXPERIMENTAL and depends on work in Xen mainline.

--- a/xen-console-srv/src/xen_console.c
+++ b/xen-console-srv/src/xen_console.c
@@ -279,6 +279,11 @@ int xen_start_domain_console(struct xen_domain *domain)
 		return -ESRCH;
 	}
 
+	if (domain->f_dom0less) {
+		LOG_ERR("dom0less domain#%u console operation not supported", domain->domid);
+		return -ENOTSUP;
+	}
+
 	console = &domain->console;
 	if (console->ext_tid) {
 		LOG_ERR("Console thread is already running for this domain!");
@@ -313,6 +318,11 @@ int xen_stop_domain_console(struct xen_domain *domain)
 	if (!domain) {
 		LOG_ERR("No domain passed to attach_domain_console");
 		return -ESRCH;
+	}
+
+	if (domain->f_dom0less) {
+		LOG_ERR("dom0less domain#%u console operation not supported", domain->domid);
+		return -ENOTSUP;
 	}
 
 	console = &domain->console;
@@ -451,6 +461,11 @@ int xen_attach_domain_console(const struct shell *shell,
 	if (!domain) {
 		LOG_ERR("No domain passed to attach_domain_console");
 		return -ESRCH;
+	}
+
+	if (domain->f_dom0less) {
+		LOG_ERR("dom0less domain#%u console operation not supported", domain->domid);
+		return -ENOTSUP;
 	}
 
 	console = &domain->console;

--- a/xen-dom-mgmt/include/domain.h
+++ b/xen-dom-mgmt/include/domain.h
@@ -169,6 +169,8 @@ struct xen_domain {
 	/* TODO: domains can have more than one console */
 	struct xen_domain_console console;
 	struct backends_state back_state;
+
+	bool f_dom0less:1; /**< Indicates that domain was created by Xen itself */
 };
 
 struct xen_domain *domid_to_domain(uint32_t domid);

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -786,6 +786,11 @@ int domain_destroy(uint32_t domid)
 		return -EINVAL;
 	}
 
+	if (domain->f_dom0less) {
+		LOG_ERR("dom0less domain#%u operation not supported", domid);
+		return -ENOTSUP;
+	}
+
 	rc = xs_remove_xenstore_backends(domid);
 	if (rc) {
 		LOG_ERR("Failed to remove_xenstore_backends domain#%u (rc=%d)", domain->domid, rc);

--- a/xenstore-srv/include/xenstore_srv.h
+++ b/xenstore-srv/include/xenstore_srv.h
@@ -47,9 +47,11 @@ struct xenstore {
  * Starts the xenstore daemon for the specified domain.
  *
  * @param domain The Xen domain to start.
+ * @param store_pfn The Xenstore PFN
+ *
  * @return 0 on success, or an error code on failure.
  */
-int start_domain_stored(struct xen_domain *domain);
+int start_domain_stored(struct xen_domain *domain, xen_pfn_t store_pfn);
 
 /**
  * Stops the xenstore daemon for the specified domain.


### PR DESCRIPTION
In case of Xen dom0less boot the number of guest domains could be started already by Xen before Zephyr is started. In this case it's required to follow the same approach as Xen tool init-dom0less is doing, because guest domains do not have Xenstore initialized, but do have Xenstore event and memory preallocated.

This patch adds Xen dom0less boot support in the following way:
- at init it checks for already started gest domains by using xen_domctl_getdomaininfo() for each Xen domid [1, CONFIG_DOM_MAX];
- for each found domain the Xenstore is initialized:
  - use HVM_PARAM_STORE_EVTCHN to get Xenstore event
  - use HVM_PARAM_MAGIC_BASE_PFN to get GFN of XEN_MAGIC pages
  - setup Xenstore
  - use HVM_PARAM_STORE_PFN to set Xenstore for guest domain
  - trigger Xenstore event

The Xen dom0less boot support is optional and can be enabled by CONFIG_XEN_DOM0LESS_BOOT Kconfig option.

This depends on [1].

[1] https://patchew.org/Xen/20240426031455.579637-1-xin.wang2@amd.com/
[2] https://github.com/xen-troops/zephyr/pull/100
Signed-off-by: Grygorii Strashko <grygorii_strashko@epam.com>