### PR TITLE
Fixes for Xenstore permission related issues

### DIFF
--- a/xen-dom-mgmt/src/xen-dom-xs.c
+++ b/xen-dom-mgmt/src/xen-dom-xs.c
@@ -508,6 +508,12 @@ int xs_initialize_xenstore(uint32_t domid, const struct xen_domain *domain)
 			 "device/suspend/event-channel",
 			 NULL };
 
+	sprintf(lbuffer, "%s/%d", basepref, domid);
+	rc = xss_write_guest_domain_rw(lbuffer, "", domid);
+	if (rc) {
+		goto deinit;
+	}
+
 	// TODO: generate properly
 	snprintf(uuid, INIT_XENSTORE_UUID_BUF_SIZE, "00000000-0000-0000-0000-%012d", domid);
 

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -859,7 +859,7 @@ static int xss_do_write(const char *const_path, const char *data, uint32_t domid
 
 		if (iter == NULL) {
 			if (parent_entry && !check_perms(parent_entry, XS_PERM_WRITE, domid)) {
-				LOG_INF("Permission denied for domid#%u (%s)", domid, path);
+				LOG_INF("Permission denied for domid#%u (%s)", domid, const_path);
 				rc = -EACCES;
 				goto free_allocated;
 			}
@@ -906,7 +906,7 @@ static int xss_do_write(const char *const_path, const char *data, uint32_t domid
 
 	if (iter && data_len > 0) {
 		if (!check_perms(iter, XS_PERM_WRITE, domid)) {
-			LOG_INF("Permission denied for domid#%u (%s)", domid, path);
+			LOG_INF("Permission denied for domid#%u (%s)", domid, const_path);
 			rc = -EACCES;
 			goto free_allocated;
 		}


### PR DESCRIPTION
Some problems were found when we tried to start 2 Linux domains connected with PV drivers. Xenstore configurations sometimes came into incorrect state and produce permissions errors. Patches in this PR fixes these problems.