### PR TITLE
Allow to use domain name instead of domid in commands

### DIFF
--- a/xen-dom-mgmt/include/domain.h
+++ b/xen-dom-mgmt/include/domain.h
@@ -123,6 +123,7 @@ struct backends_state {
 
 struct xen_domain_cfg {
 	char name[CONTAINER_NAME_SIZE];
+	char domain_name[CONTAINER_NAME_SIZE];
 	const char **machine_dt_compat;
 	uint32_t nr_machine_dt_compat;
 	uint64_t mem_kb;

--- a/xen-dom-mgmt/include/xen_dom_mgmt.h
+++ b/xen-dom-mgmt/include/xen_dom_mgmt.h
@@ -87,6 +87,16 @@ int domain_get_user_cfg_count(void);
  */
 struct xen_domain_cfg *domain_get_user_cfg(int index);
 
+/**
+ * This function fetches the domain name by domain ID.
+ *
+ * @param domain_id The ID of the domain.
+ * @param name The buffer to store the domain name.
+ * @param len The length of the buffer.
+ * @return 0 on success, or an error code on failure.
+ */
+int get_domain_name(unsigned short domain_id, char *name, int len);
+
 #ifdef CONFIG_XEN_DOMCFG_SECTION
 #define DECL_CONFIG static __section(".domain_configs") __used
 extern struct xen_domain_cfg _domain_configs_start[];

--- a/xen-dom-mgmt/include/xen_dom_mgmt.h
+++ b/xen-dom-mgmt/include/xen_dom_mgmt.h
@@ -97,6 +97,14 @@ struct xen_domain_cfg *domain_get_user_cfg(int index);
  */
 int get_domain_name(unsigned short domain_id, char *name, int len);
 
+/**
+ * This function fetches the domain ID by domain name.
+ *
+ * @param name The name of the domain.
+ * @return The domain ID on success, or an error code on failure.
+ */
+uint32_t find_domain_by_name(char *arg);
+
 #ifdef CONFIG_XEN_DOMCFG_SECTION
 #define DECL_CONFIG static __section(".domain_configs") __used
 extern struct xen_domain_cfg _domain_configs_start[];

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/xen/dom0/domctl.h>
+#include <zephyr/xen/dom0/sysctl.h>
 #include <zephyr/xen/hvm.h>
 #include <zephyr/logging/log.h>
 
@@ -619,6 +620,18 @@ struct xen_domain_cfg *domain_find_config(const char *name)
 #endif
 
 	return NULL;
+}
+
+int get_domain_name(unsigned short domain_id, char *name, int len)
+{
+#ifdef CONFIG_XEN_STORE_SRV
+	char path[sizeof("/local/domain/32768/name")];
+
+	snprintf(path, sizeof(path), "/local/domain/%u/name", domain_id);
+	return xss_read(path, name, len);
+#else
+	return -EINVAL;
+#endif
 }
 
 __weak int domain_get_user_cfg_count(void)

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -634,6 +634,32 @@ int get_domain_name(unsigned short domain_id, char *name, int len)
 #endif
 }
 
+uint32_t find_domain_by_name(char *arg)
+{
+	char domname[CONTAINER_NAME_SIZE];
+	struct xen_domctl_getdomaininfo infos[CONFIG_DOM_MAX];
+	uint32_t domid = 0;
+	int i, ret;
+
+	ret = xen_sysctl_getdomaininfo(infos, 0, CONFIG_DOM_MAX);
+	if (ret < 0) {
+		goto out;
+	}
+
+	for (i = 0; i < ret; i++) {
+		if (!get_domain_name(infos[i].domain, domname,
+					    CONTAINER_NAME_SIZE)) {
+			if (strncmp(domname, arg, CONTAINER_NAME_SIZE) == 0) {
+				domid = infos[i].domain;
+				break;
+			}
+		}
+	}
+
+out:
+	return domid;
+}
+
 __weak int domain_get_user_cfg_count(void)
 {
 	return 0;

--- a/xen-shell-cmd/src/xstat_cmds.c
+++ b/xen-shell-cmd/src/xstat_cmds.c
@@ -9,72 +9,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/shell/shell.h>
 
-struct status_func {
-	unsigned int (*get_status)(int state);
-	char ch;
-};
-
-/* Get domain states */
-static unsigned int xstat_dying(int state)
-{
-	return (state & XEN_DOMINF_dying) == XEN_DOMINF_dying;
-}
-
-static unsigned int xstat_crashed(int state)
-{
-	return ((state & XEN_DOMINF_shutdown) == XEN_DOMINF_shutdown) &&
-		(((state >> XEN_DOMINF_shutdownshift) &
-		XEN_DOMINF_shutdownmask) == SHUTDOWN_crash);
-}
-
-static unsigned int xstat_shutdown(int state)
-{
-	return ((state & XEN_DOMINF_shutdown) == XEN_DOMINF_shutdown) &&
-		(((state >> XEN_DOMINF_shutdownshift) &
-		XEN_DOMINF_shutdownmask) != SHUTDOWN_crash);
-}
-
-static unsigned int xstat_paused(int state)
-{
-	return (state & XEN_DOMINF_paused) == XEN_DOMINF_paused;
-}
-
-static unsigned int xstat_blocked(int state)
-{
-	return (state & XEN_DOMINF_blocked) == XEN_DOMINF_blocked;
-}
-
-static unsigned int xstat_running(int state)
-{
-	return (state & XEN_DOMINF_running) == XEN_DOMINF_running;
-}
-
-static const struct status_func status_funcs[] = {
-	{ xstat_dying,    'd' },
-	{ xstat_shutdown, 's' },
-	{ xstat_blocked,  'b' },
-	{ xstat_crashed,  'c' },
-	{ xstat_paused,   'p' },
-	{ xstat_running,  'r' }
-};
-
-const unsigned int NUM_STATES = ARRAY_SIZE(status_funcs);
-
-static char *print_state(struct xenstat_domain *domain, char *buff)
-{
-	unsigned int i;
-	char *c;
-
-	if (!buff) {
-		return NULL;
-	}
-	buff[NUM_STATES] = 0;
-	for (i = 0, c = buff; i < NUM_STATES; i++) {
-		*c++ = status_funcs[i].get_status(domain->state) ? status_funcs[i].ch : '-';
-	}
-	return buff;
-}
-
 static int xstat_shell_vers(const struct shell *shell, size_t argc, char **argv)
 {
 	struct xenstat stat;
@@ -89,13 +23,10 @@ static int xstat_shell_vers(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int xstat_shell_stat(const struct shell *shell, size_t argc, char **argv)
+static int xstat_shell_physinfo(const struct shell *shell, size_t argc, char **argv)
 {
 	struct xenstat stat;
 	int ret;
-	char buff[NUM_STATES + 1];
-	struct xenstat_domain domain;
-	int max_domid;
 
 	ret = xstat_getstat(&stat);
 	if (ret < 0) {
@@ -107,30 +38,6 @@ static int xstat_shell_stat(const struct shell *shell, size_t argc, char **argv)
 	shell_print(shell, "CPU freq(kHz): %lld", stat.cpu_hz / 1000);
 	shell_print(shell, "Total mem(K) : %llu", stat.tot_mem / 1024);
 	shell_print(shell, "Free mem(K)  : %llu", stat.free_mem / 1024);
-	max_domid = 0;
-	while (1) {
-		ret = xstat_getdominfo(&domain, max_domid, 1);
-		if (ret < 0) {
-			shell_error(shell, "Cold not get info for domain %d", max_domid);
-			break;
-		}
-		if (ret == 0) {
-			break;
-		}
-		if (domain.id + 1 > max_domid) {
-			max_domid = domain.id + 1;
-		}
-		shell_print(shell, "Domain #%3d     : %s", domain.id, domain.name);
-		shell_print(shell, "State           : %s", print_state(&domain, buff));
-		shell_print(shell, "CPU ns          : %lld", domain.cpu_ns);
-		shell_print(shell, "VCPUs           : %d", domain.num_vcpus);
-		shell_print(shell, "MEM reserved(K) : %lld", domain.cur_mem / 1024);
-		shell_print(shell, "MEM allowed(K)  : %lld",
-			    ((long long)domain.max_mem == -1) ? -1
-			    : domain.max_mem / 1024);
-		shell_print(shell, "SSID            : %d", domain.ssid);
-		shell_print(shell, "---------------------------------");
-	}
 
 	return ret;
 }
@@ -140,9 +47,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(version, NULL,
 		      " Version command\n",
 		      xstat_shell_vers, 1, 0),
-	SHELL_CMD_ARG(stat, NULL,
+	SHELL_CMD_ARG(physinfo, NULL,
 		      " stat command\n",
-		      xstat_shell_stat, 1, 0),
+		      xstat_shell_physinfo, 1, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_ARG_REGISTER(xstat, &subcmd_xstat, "XStat commands", NULL, 2, 0);


### PR DESCRIPTION
Add the ability to use domain name instead of domid in the xu shell
commands. If the passed identifier is all numbers, then it is
considered as domid, otherwise, it is considered as domain name.
Updated commands description to reflect this change.

Also add the command to list domain infos so we can actually know the domain names.
Fixes https://github.com/xen-troops/zephyr-xenlib/issues/71