### PR TITLE
xen_console: Fix deadlock in xen_stop_domain_console()

### DIFF
--- a/xen-console-srv/src/xen_console.c
+++ b/xen-console-srv/src/xen_console.c
@@ -345,10 +345,11 @@ int xen_stop_domain_console(struct xen_domain *domain)
 	/* Stop attached console if any */
 	if (current_console == console) {
 		k_sem_give(&console->int_sem);
+		k_mutex_unlock(&global_console_lock);
 		k_thread_join(&console->int_thrd, K_FOREVER);
-		current_console = NULL;
+	} else {
+		k_mutex_unlock(&global_console_lock);
 	}
-	k_mutex_unlock(&global_console_lock);
 
 	k_free(console->int_buf);
 


### PR DESCRIPTION
Both xen_stop_domain_console and console thread are trying to acquire global_console_lock and unset current_console at the same time. This can prevent console thread from ever stopping if xen_stop_domain_console acquires the lock first.

This patch fixes the issue by unlocking the global_console_lock before joining the console thread, and leaving the job of unsetting the current console to the console thread.