### PR TITLE
xen-dom-mgmt: do not left domain paused on creation

### DIFF
--- a/xen-dom-mgmt/include/domain.h
+++ b/xen-dom-mgmt/include/domain.h
@@ -131,6 +131,8 @@ struct xen_domain_cfg {
 	void *image_info;
 
 	struct backend_configuration back_cfg;
+
+	bool f_paused:1; /**< Domain should remain paused after creation */
 };
 
 struct xen_domain_console {

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -53,8 +53,6 @@ struct modules_address {
  * This variable used during shell command execution, thus requires no sync. */
 static int dom_num = 0;
 
-#define DOMID_DOMD 1
-
 /* Define major and minor versions if was not provided */
 #ifndef XEN_VERSION_MAJOR
 #define XEN_VERSION_MAJOR 4
@@ -777,14 +775,10 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 		goto stop_domain_console;
 	}
 
-	if (domid == DOMID_DOMD) {
-		rc = xen_domctl_unpausedomain(domid);
-		if (rc) {
-			LOG_ERR("Failed to unpause domain#%u (rc=%d)", domid, rc);
-			goto stop_domain_console;
-		}
-	} else {
-		LOG_INF("Created domain is paused\nTo unpause issue: xu unpause %u", domid);
+	rc = xen_domctl_unpausedomain(domid);
+	if (rc) {
+		LOG_ERR("Failed to unpause domain#%u (rc=%d)", domid, rc);
+		goto stop_domain_console;
 	}
 
 	k_mutex_lock(&dl_mutex, K_FOREVER);

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -775,10 +775,12 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 		goto stop_domain_console;
 	}
 
-	rc = xen_domctl_unpausedomain(domid);
-	if (rc) {
-		LOG_ERR("Failed to unpause domain#%u (rc=%d)", domid, rc);
-		goto stop_domain_console;
+	if (!domcfg->f_paused) {
+		rc = xen_domctl_unpausedomain(domid);
+		if (rc) {
+			LOG_ERR("Failed to unpause domain#%u (rc=%d)", domid, rc);
+			goto stop_domain_console;
+		}
 	}
 
 	k_mutex_lock(&dl_mutex, K_FOREVER);

--- a/xen-shell-cmd/src/xen_cmds.c
+++ b/xen-shell-cmd/src/xen_cmds.c
@@ -33,6 +33,18 @@ uint32_t parse_domid(size_t argc, char **argv)
 	return 0;
 }
 
+void parse_and_fill_flags(size_t argc, char **argv, struct xen_domain_cfg *cfg)
+{
+	int i;
+
+	for (i = 0; i < argc; i++) {
+		/* check if domain should remain paused after creation */
+		if (argv[i][0] == '-' && argv[i][1] == 'p') {
+			cfg->f_paused = 1;
+		}
+	}
+}
+
 static int domu_create(const struct shell *shell, int argc, char **argv)
 {
 	int ret;
@@ -56,6 +68,8 @@ static int domu_create(const struct shell *shell, int argc, char **argv)
 		shell_error(shell, "Config %s not found", name);
 		return -EINVAL;
 	}
+
+	parse_and_fill_flags(argc, argv, cfg);
 
 	ret = domain_create(cfg, domid);
 	if (ret < 0) {
@@ -165,8 +179,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	subcmd_xu,
 	SHELL_CMD_ARG(create, NULL,
 		      " Create Xen domain\n"
-		      " Usage: create cfg_name [-d <domid>]\n",
-		      domu_create, 2, 2),
+		      " Usage: create cfg_name [-d <domid>] [-p]\n",
+		      domu_create, 2, 3),
 	SHELL_CMD_ARG(destroy, NULL,
 		      " Destroy Xen domain\n"
 		      " Usage: destroy <domid>\n",


### PR DESCRIPTION
Some hacky logic were added previously on domain creation - only Domain-D is unpaused after domain_create(). This looks like hack, that definitely should be removed from mainline library.