### PR TITLE
xen-dom-mgmt: Use correct domid for domain_post_create

### DIFF
--- a/xen-dom-mgmt/include/xen_dom_mgmt.h
+++ b/xen-dom-mgmt/include/xen_dom_mgmt.h
@@ -19,7 +19,7 @@ extern "C" {
  *
  * @param domcfg The configuration for the new domain.
  * @param domid The ID of the new domain.
- * @return 0 on success, or an error code on failure.
+ * @return domid on success, or a negative error code on failure.
  */
 int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid);
 

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -793,7 +793,11 @@ int domain_create(struct xen_domain_cfg *domcfg, uint32_t domid)
 	++dom_num;
 	k_mutex_unlock(&dl_mutex);
 
-	return rc;
+	if (rc) {
+		return rc;
+	}
+
+	return domid;
 
 stop_domain_console:
 #ifdef CONFIG_XEN_CONSOLE_SRV

--- a/xen-shell-cmd/src/xen_cmds.c
+++ b/xen-shell-cmd/src/xen_cmds.c
@@ -58,11 +58,11 @@ static int domu_create(const struct shell *shell, int argc, char **argv)
 	}
 
 	ret = domain_create(cfg, domid);
-	if (ret) {
+	if (ret < 0) {
 		return ret; /* domain_create should care about error logs */
 	}
 
-	return domain_post_create(cfg, domid);
+	return domain_post_create(cfg, ret);
 }
 
 int domu_destroy(const struct shell *shell, size_t argc, char **argv)


### PR DESCRIPTION
Currently, when domid auto allocation is used, we pass 0 to domain_post_create, causing it to fail. Fix this by returning the allocated domid from domain_create and passing it to domain_post_create.