### PR TITLE
Xenlib update to support fatfs on sdmmc

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -20,7 +20,6 @@ config XEN_LIBFDT
 config PARTIAL_DEVICE_TREE_SIZE
 	int "Domain device tree size"
 	default 8192
-	depends on XEN_LIBFDT
 	help
 	  Maximum size of the domain device tree
 
@@ -39,6 +38,16 @@ config XEN_DOMCFG_SECTION
 	  This allows you to declare multiple domain configs with
 	  a DECL_CONFIG macro. Configs can be later accessed by
 	  their name.
+
+config XEN_DOMCFG_READ_PDT
+	bool "Enable reading of domain partial device-tree (PDT) binary"
+	default y
+	depends on XEN_DOMAIN_MANAGEMENT
+	help
+	  Enables reading of domain partial device-tree (PDT) binary by using
+	  callbacks in struct xen_domain_cfg.
+	  It also enables this feature in "xu create" shell command which will
+	  try to load PDT binary using struct xen_domain_cfg callbacks.
 
 config XEN_CONSOLE_SRV
 	bool "Enable Xen Console server"

--- a/Kconfig
+++ b/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Peter Bigot Consulting, LLC
+# Copyright (c) 2024 EPAM Systems
 # SPDX-License-Identifier: Apache-2.0
 
 mainmenu "Xen Libraries"
@@ -86,49 +86,6 @@ config VCH_PATH_MAXLEN
 	help
 	  The maximum XenStore path size that identify a separate vchannel.
 
-config XRUN
-	bool "Enable XRUN support"
-	select JSON_LIBRARY
-	help
-	  Enable xrun support which allows to run domains based on the runtime spec.
-
-config XRUN_JSON_SIZE_MAX
-	int "Maximum size of the json cni spec"
-	default 8192
-	depends on XRUN
-	help
-	  Sets the maximum size of the cni spec json that could
-	  be passed to xrun call.
-
-config XRUN_MAX_PATH_SIZE
-	int "Maximum length of file path to read from storage"
-	default 255
-	help
-	  Sets the maximum path size that xrun can read from storage.
-	  The default value is set to LFS_NAME_MAX which is default
-	  for littlefs configuration.
-
-config XRUN_DTDEVS_MAX
-	int "Maximum numbers of the provided dtdevs"
-	default 20
-	help
-	  Sets the maximum number of the dtdevs configuration
-	  provided in the OCI spec.
-
-config XRUN_IOMEMS_MAX
-	int "Maximum numbers of the provided iomems"
-	default 20
-	help
-	  Sets the maximum number of the iomems configuration
-	  provided in the OCI spec.
-
-config XRUN_IRQS_MAX
-	int "Maximum numbers of the provided irqs"
-	default 20
-	help
-	  Sets the maximum number of the irqs configuration
-	  provided in the OCI spec.
-
 config PFN_CHUNK_SIZE
 	int "Chunk size for memory mapping operations"
 	default 128
@@ -163,3 +120,5 @@ config XEN_DOM0LESS_BOOT
 	  xenstore will be initialized.
 
 	  This is EXPERIMENTAL and depends on work in Xen mainline.
+
+rsource "./xrun/Kconfig"

--- a/xen-dom-mgmt/include/domain.h
+++ b/xen-dom-mgmt/include/domain.h
@@ -53,6 +53,35 @@ typedef int (*load_image_bytes_t)(uint8_t *buf, size_t bufsize,
  */
 typedef ssize_t (*get_image_size_t)(void *image_info, uint64_t *size);
 
+/**
+ * @typedef image_dt_read_cb_t
+ * @brief Partial device-tree (PDT) binary read callback
+ *
+ * Function callback, that should load @ref bufsize domain's PDT image binary to given buffer.
+ * The xenlib will attempt to load PDT if @ref dtb_start is not provided.
+ *
+ * @param buf buffer, where bytes should be loaded
+ * @param bufsize number of bytes, that should be loaded
+ * @param read_offset number of bytes, that should be skipped from image start
+ * @param image_info private data, passed to callback
+ * @return 0 on success, negative errno on error
+ */
+typedef int (*image_dt_read_cb_t)(uint8_t *buf, size_t bufsize, uint64_t read_offset,
+				  void *image_info);
+
+/**
+ * @typedef image_dt_get_size_cb_t
+ * @brief Partial device-tree (PDT) binary get size callback
+ *
+ * Function callback, that should return domain's PDT image size in bytes.
+ * The xenlib will attempt to load PDT if @ref dtb_start is not provided.
+ *
+ * @param image_info private data, that can be passed to callback
+ * @param size output parameter, uint64_t pointer to result
+ * @return 0 on success, negative errno on error
+ */
+typedef int (*image_dt_get_size_cb_t)(void *image_info, size_t *size);
+
 struct pv_net_configuration {
 	bool configured;
 	int backend_domain_id;
@@ -124,6 +153,10 @@ struct xen_domain_cfg {
 	char *cmdline;
 
 	const char *dtb_start, *dtb_end;
+#if defined(CONFIG_XEN_DOMCFG_READ_PDT)
+	image_dt_read_cb_t image_dt_read;
+	image_dt_get_size_cb_t image_dt_get_size;
+#endif /* CONFIG_XEN_DOMCFG_READ_PDT */
 
 	load_image_bytes_t load_image_bytes;
 	get_image_size_t get_image_size;

--- a/xrun/Kconfig
+++ b/xrun/Kconfig
@@ -45,4 +45,15 @@ config XRUN_IRQS_MAX
 	  Sets the maximum number of the irqs configuration
 	  provided in the OCI spec.
 
+config XRUN_STORAGE_DMA_DEBOUNCE
+	int "Set debounce buffer for FS storage access in KB"
+	default 4
+	help
+	  Sets debounce buffer for FS storage access in KB which is required to
+	  enable DMA for storage devices. The xenlib may use DMA incompatible
+	  buffers for reading guest domain kernel binaries using forging memory,
+	  mapped in Dom0 address space. These buffers may not be contiguous and
+	  phys/dma address can't be obtained for this buffers.
+	  In such cases enables this option.
+
 endif # XRUN

--- a/xrun/Kconfig
+++ b/xrun/Kconfig
@@ -1,0 +1,48 @@
+# Copyright (c) 2024 EPAM Systems
+# SPDX-License-Identifier: Apache-2.0
+
+config XRUN
+	bool "Enable XRUN support"
+	select JSON_LIBRARY
+	help
+	  Enable xrun support which allows to run domains based on the runtime spec.
+
+if XRUN
+
+config XRUN_JSON_SIZE_MAX
+	int "Maximum size of the json cni spec"
+	default 8192
+	help
+	  Sets the maximum size of the cni spec json that could
+	  be passed to xrun call.
+
+config XRUN_MAX_PATH_SIZE
+	int "Maximum length of file path to read from storage"
+	default 255
+	help
+	  Sets the maximum path size that xrun can read from storage.
+	  The default value is set to LFS_NAME_MAX which is default
+	  for littlefs configuration.
+
+config XRUN_DTDEVS_MAX
+	int "Maximum numbers of the provided dtdevs"
+	default 20
+	help
+	  Sets the maximum number of the dtdevs configuration
+	  provided in the OCI spec.
+
+config XRUN_IOMEMS_MAX
+	int "Maximum numbers of the provided iomems"
+	default 20
+	help
+	  Sets the maximum number of the iomems configuration
+	  provided in the OCI spec.
+
+config XRUN_IRQS_MAX
+	int "Maximum numbers of the provided irqs"
+	default 20
+	help
+	  Sets the maximum number of the irqs configuration
+	  provided in the OCI spec.
+
+endif # XRUN

--- a/xrun/src/storage.c
+++ b/xrun/src/storage.c
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
- * Copyright (c) 2023 EPAM Systems
+ * Copyright (c) 2024 EPAM Systems
  */
 #include <stdio.h>
 
 #include <zephyr/device.h>
 #include <zephyr/fs/fs.h>
-#include <zephyr/fs/littlefs.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 


### PR DESCRIPTION
This series is prerequisite to enable FATFS storage on SDMMC for zephyr-dom0-xt application, instead of default littlefs.

It fixes build failure when littlefs is not enabled.

It adds support for DMA debounce buffer in xrun/storage which is required to enable DMA for SDMMC device, because xenlib loads Kernel image directly in foreign guest domain memory which can be used with DMA.

It adds  option to read domain partial device-tree binary from storage with "xu create" shell command.