### PR TITLE
Xenlib update domain mgmt cmds logs

### DIFF
--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -877,6 +877,9 @@ int domain_pause(uint32_t domid)
 	}
 
 	rc = xen_domctl_pausedomain(domid);
+	if (rc) {
+		LOG_ERR("domain:%u pause failed (%d)", domid, rc);
+	}
 
 	return rc;
 }
@@ -884,6 +887,7 @@ int domain_pause(uint32_t domid)
 int domain_unpause(uint32_t domid)
 {
 	struct xen_domain *domain = NULL;
+	int rc;
 
 	domain = domid_to_domain(domid);
 	if (!domain) {
@@ -892,7 +896,12 @@ int domain_unpause(uint32_t domid)
 		return -EINVAL;
 	}
 
-	return xen_domctl_unpausedomain(domid);
+	rc = xen_domctl_unpausedomain(domid);
+	if (rc) {
+		LOG_ERR("domain:%u unpause failed (%d)", domid, rc);
+	}
+
+	return rc;
 }
 
 int domain_post_create(const struct xen_domain_cfg *domcfg, uint32_t domid)

--- a/xen-shell-cmd/src/xen_cmds.c
+++ b/xen-shell-cmd/src/xen_cmds.c
@@ -134,11 +134,19 @@ static int domu_create(const struct shell *shell, int argc, char **argv)
 		return ret; /* domain_create should care about error logs */
 	}
 
-	return domain_post_create(cfg, ret);
+	domid = ret;
+	ret = domain_post_create(cfg, domid);
+	if (ret) {
+		return ret;
+	}
+
+	shell_info(shell, "domain:%u created", domid);
+	return 0;
 }
 
 int domu_destroy(const struct shell *shell, size_t argc, char **argv)
 {
+	int ret;
 	uint32_t domid = 0;
 
 	if (argc != 2)
@@ -150,7 +158,13 @@ int domu_destroy(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	return domain_destroy(domid);
+	ret = domain_destroy(domid);
+	if (ret) {
+		return ret;
+	}
+
+	shell_info(shell, "domain:%u destroyed", domid);
+	return 0;
 }
 
 #ifdef CONFIG_XEN_CONSOLE_SRV
@@ -182,6 +196,7 @@ int domu_console_attach(const struct shell *shell, size_t argc, char **argv)
 int domu_pause(const struct shell *shell, size_t argc, char **argv)
 {
 	uint32_t domid = 0;
+	int ret;
 
 	if (argc != 2)
 		return -EINVAL;
@@ -192,12 +207,19 @@ int domu_pause(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	return domain_pause(domid);
+	ret = domain_pause(domid);
+	if (ret) {
+		return ret;
+	}
+
+	shell_info(shell, "domain:%u paused", domid);
+	return 0;
 }
 
 int domu_unpause(const struct shell *shell, size_t argc, char **argv)
 {
 	uint32_t domid = 0;
+	int ret;
 
 	if (argc != 2)
 		return -EINVAL;
@@ -208,7 +230,13 @@ int domu_unpause(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	return domain_unpause(domid);
+	ret = domain_unpause(domid);
+	if (ret) {
+		return ret;
+	}
+
+	shell_info(shell, "domain:%u unpaused", domid);
+	return 0;
 }
 
 int xen_config_list(const struct shell *shell, size_t argc, char **argv)


### PR DESCRIPTION
The intention of this PR is to update update domain mgmt cmds logs, so `xu create/pause/unpause/destroy` always produce some log output (on success and on failure), so it can be used by automatic tests like pytest.

On success log output looks like

`domain:%u created|destroyed|paused|unpaused`