### PR TITLE
xen-dom-mgmt: add domains xsm security labels id cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,39 @@ config XEN_DOMAIN_MANAGEMENT
 config XEN_CONSOLE_SRV
 ```
 For more information on the configuration options, please refer to the `Kconfig` file.
+
+## Xen Security Modules (XSM) - FLASK support (experimental)
+
+The XSM policy is completely user defined, and any IDs associated with policy
+elements (like user, role and type) are auto-generated at Xen build time.
+
+For XSM to work properly the domU need to be marked with security label
+in their configuration. Without this the domains will be classified “unlabeled”.
+
+Example line from a domU configuration (xl.cfg):
+```
+seclabel='system_u:system_r:domU_t'
+```
+
+In Linux world, the pretty complex set of Xen tools is responsible for
+converting from above security label string into numeric SSID value used by
+Xen internally. For example, below conversion happens with XSM domain security
+label, specified in very simplified form:
+```
+    seclabel='system_u:system_r:domU_t' => domU => SECINITSID_DOMU => 12
+```
+
+Hence in Zephyr such tools are absent the only available option right now is
+to get SSID values from auto-generated Xen xen/xen/xsm/flask/include/flask.h
+header.
+
+The zephyr-xenlib allows to specify XSM security labels SSID in `ssidref" field
+of the struct xen_domain_cfg.
+
+Example of labelig of domU with `domU_t` type:
+```
+struct xen_domain_cfg domd_cfg = {
+	...
+	.ssidref = 12,
+};
+```

--- a/xen-dom-mgmt/include/domain.h
+++ b/xen-dom-mgmt/include/domain.h
@@ -132,6 +132,7 @@ struct xen_domain_cfg {
 	uint32_t max_evtchns;
 	int32_t gnt_frames;
 	int32_t max_maptrack_frames;
+	uint32_t ssidref; /**< XSM security labels id */
 
 	/* ARM arch related */
 	uint8_t gic_version;

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -76,6 +76,7 @@ static void prepare_domain_cfg(struct xen_domain_cfg *dom_cfg,
 	create->max_evtchn_port = dom_cfg->max_evtchns;
 	create->max_grant_frames = dom_cfg->gnt_frames;
 	create->max_maptrack_frames = dom_cfg->max_maptrack_frames;
+	create->ssidref = dom_cfg->ssidref;
 
 	arch_prepare_domain_cfg(dom_cfg, &create->arch);
 }


### PR DESCRIPTION
The XSM policy is completely user defined, and any IDs associated with policy elements (like user, role and type) are auto-generated. The pretty complex Xen tools are responsible for converting from string "seclabel" (xl.cfg) into SSID used by Xen.

For example, below conversion happens with XSM security label, specified in xl.cfg (very simplified):

seclabel='system_u:system_r:domU_t' => domU => SECINITSID_DOMU => 12

As result, the only available option right now is to allow user to specify domain SSID in struct xen_domain_cfg.

This patch adds possibility to specify XSM security labels id for domain in struct xen_domain_cfg, which than is passed to Xen unchanged during domain creation.