### PR TITLE
xrun: update xrun_run to work with new behaviour of domain_create

### DIFF
--- a/xrun/src/xrun.c
+++ b/xrun/src/xrun.c
@@ -596,7 +596,7 @@ int xrun_run(const char *bundle, int console_socket, const char *container_id)
 	}
 
 	ret = domain_create(&domcfg, container->domid);
-	if (ret) {
+	if (ret < 0) {
 		k_mutex_unlock(&container_run_lock);
 		goto err_config;
 	}

--- a/xrun/src/xrun.c
+++ b/xrun/src/xrun.c
@@ -602,12 +602,6 @@ int xrun_run(const char *bundle, int console_socket, const char *container_id)
 	}
 
 	ret = domain_post_create(&domcfg, container->domid);
-	if (ret) {
-		k_mutex_unlock(&container_run_lock);
-		goto err_config;
-	}
-
-	ret = domain_unpause(container->domid);
 
 	k_free(config);
 	k_free(domcfg.cmdline);


### PR DESCRIPTION
On the latest version of the domain_create call it's work behavoiur was changed to return domid instead of 0 if operation was succeeded. Also, domain is started automatically so update xrun_run call to match the new device_create call revision.