### PR TITLE
vch: use correct structure for grant unmapping

### DIFF
--- a/vch/include/vch.h
+++ b/vch/include/vch.h
@@ -22,6 +22,7 @@ extern "C" {
 struct vch_handle {
 	evtchn_port_t evtch;
 	grant_ref_t gref;
+	grant_handle_t grant_handle;
 	bool blocking;
 	struct k_sem sem;
 	bool is_server;


### PR DESCRIPTION
Zephyr grant table driver used incorrect structure for grant entries unmapping. Recently it was fixed and now causes warnings during build of vchan related code, since it was developed according to previous functions signatures.

Rework vchan to use correct 'struct gnttab_unmap_grant_ref' for grant entries unmapping procedures. Since this structure uses grant handles instead of gref, add such member it to vch_handle struct.