### PR TITLE
xen-shell-cmd: Add options for shell for xenstore-srv and domain-mgmt.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -9,6 +9,14 @@ config XEN_STORE_SRV
 	  Enable xenstore server library. It should be included
 	  if you are running Zephyr as Dom0.
 
+config XEN_STORE_SRV_SHELL_CMDS
+	depends on SHELL
+	depends on XEN_STORE_SRV
+	default y
+	bool "Enable XenStore server shell"
+	help
+	  Enable shell for XenStore server.
+
 config XEN_LIBFDT
 	bool "Enable libfdt support"
 	help
@@ -28,6 +36,14 @@ config XEN_DOMAIN_MANAGEMENT
 	help
 	  Enable domain management library. This library allows you
 	  to create, destroy and manage xen domains.
+
+config XEN_DOMAIN_MANAGEMENT_SHELL_CMDS
+	depends on SHELL
+	depends on XEN_DOMAIN_MANAGEMENT
+	default y
+	bool "Enable Xen domain management shell"
+	help
+	  Enable shell for Xen domain management.
 
 config XEN_DOMCFG_SECTION
 	bool "Enable Xen domain config section"

--- a/xen-shell-cmd/CMakeLists.txt
+++ b/xen-shell-cmd/CMakeLists.txt
@@ -3,7 +3,7 @@
 add_library(XEN_SHELL INTERFACE)
 
 zephyr_library()
-zephyr_library_sources(src/xen_cmds.c)
-zephyr_library_sources(src/xenstore_cmds.c)
+zephyr_library_sources_ifdef(CONFIG_XEN_DOMAIN_MANAGEMENT_SHELL_CMDS src/xen_cmds.c)
+zephyr_library_sources_ifdef(CONFIG_XEN_STORE_SRV_SHELL_CMDS src/xenstore_cmds.c)
 zephyr_library_sources_ifdef(CONFIG_XSTAT_SHELL_CMDS src/xstat_cmds.c)
 zephyr_library_link_libraries(XEN_SHELL)


### PR DESCRIPTION
The shell function for xenstore server and domain management can now be switched using Kconfig
so that it can be disabled if not needed.
The default value is `y` for compatibility reasons.