### PR TITLE
xen-console-srv: Add `user_data` to the arguments of `shell_set_bypass`.

### DIFF
--- a/xen-console-srv/src/xen_console.c
+++ b/xen-console-srv/src/xen_console.c
@@ -438,9 +438,11 @@ static void console_display_thrd(void *p1, void *p2, void *p3)
 }
 
 static void console_shell_cb(const struct shell *shell,
-			     uint8_t *data, size_t len)
+			     uint8_t *data, size_t len, void *user_data)
 {
 	struct xen_domain_console *console;
+
+	ARG_UNUSED(user_data);
 
 	k_mutex_lock(&global_console_lock, K_FOREVER);
 	console = current_console;
@@ -449,7 +451,7 @@ static void console_shell_cb(const struct shell *shell,
 	if (!console) {
 		/* This may happen if xen_stop_domain_console() was
 		 * called when console is still attached */
-		shell_set_bypass(shell, NULL);
+		shell_set_bypass(shell, NULL, NULL);
 		return;
 	}
 
@@ -457,7 +459,7 @@ static void console_shell_cb(const struct shell *shell,
 		/* Detach console */
 		atomic_set_bit(&console->stop_thrd, INT_THREAD_STOP_BIT);
 		k_sem_give(&console->int_sem);
-		shell_set_bypass(shell, NULL);
+		shell_set_bypass(shell, NULL, NULL);
 		return;
 	}
 
@@ -505,7 +507,7 @@ int xen_attach_domain_console(const struct shell *shell,
 			console_display_thrd, console,
 			(void *)shell, NULL, XEN_CONSOLE_PRIO, 0, K_NO_WAIT);
 
-	shell_set_bypass(shell, console_shell_cb);
+	shell_set_bypass(shell, console_shell_cb, NULL);
 
 	put_domain(domain);
 	return 0;

--- a/xen-console-srv/src/xen_console.c
+++ b/xen-console-srv/src/xen_console.c
@@ -442,9 +442,11 @@ static void console_display_thrd(void *p1, void *p2, void *p3)
 }
 
 static void console_shell_cb(const struct shell *shell,
-			     uint8_t *data, size_t len)
+			     uint8_t *data, size_t len, void *user_data)
 {
 	struct xen_domain_console *console;
+
+	ARG_UNUSED(user_data);
 
 	k_mutex_lock(&global_console_lock, K_FOREVER);
 	console = current_console;
@@ -453,7 +455,7 @@ static void console_shell_cb(const struct shell *shell,
 	if (!console) {
 		/* This may happen if xen_stop_domain_console() was
 		 * called when console is still attached */
-		shell_set_bypass(shell, NULL);
+		shell_set_bypass(shell, NULL, NULL);
 		return;
 	}
 
@@ -461,7 +463,7 @@ static void console_shell_cb(const struct shell *shell,
 		/* Detach console */
 		atomic_set_bit(&console->stop_thrd, INT_THREAD_STOP_BIT);
 		k_sem_give(&console->int_sem);
-		shell_set_bypass(shell, NULL);
+		shell_set_bypass(shell, NULL, NULL);
 		return;
 	}
 
@@ -509,7 +511,7 @@ int xen_attach_domain_console(const struct shell *shell,
 			console_display_thrd, console,
 			(void *)shell, NULL, XEN_CONSOLE_PRIO, 0, K_NO_WAIT);
 
-	shell_set_bypass(shell, console_shell_cb);
+	shell_set_bypass(shell, console_shell_cb, NULL);
 
 	put_domain(domain);
 	return 0;


### PR DESCRIPTION
The API has been changed in
https://github.com/zephyrproject-rtos/zephyr/commit/3695b2c0caee697e7d9, so we are updating accordingly.

This PR requires zephyr-v4.4.0 later.
related:
https://github.com/xen-troops/zephyr-xenlib/pull/113
https://github.com/xen-troops/zephyr-dom0-xt/pull/44

https://github.com/soburi/zephyr/tree/zephyr-v4.4.0-xt
(I tried making it myself for now, but it would be better if the person in charge handled the rebase of zephyr-v4.3.0-xt.)