### PR TITLE
include: xen: public: xen-compat: Always define __XEN_INTERFACE_VERSION

### DIFF
--- a/include/xen/public/xen-compat.h
+++ b/include/xen/public/xen-compat.h
@@ -15,9 +15,11 @@
 
 #ifdef CONFIG_XEN_DOM0
 #define __XEN_TOOLS__
-/* Xen is built with matching headers and implements the latest interface. */
+#endif
+
+#ifdef CONFIG_XEN_INTERFACE_VERSION
 #define __XEN_INTERFACE_VERSION__ CONFIG_XEN_INTERFACE_VERSION
-#elif !defined(__XEN_INTERFACE_VERSION__)
+#else
 /* Guests which do not specify a version get the legacy interface. */
 #define __XEN_INTERFACE_VERSION__ 0x00000000
 #endif


### PR DESCRIPTION
This update fixes an issue where the __XEN_INTERFACE_VERSION__ was not defined when CONFIG_XEN_DOM0 was not set.