### PR TITLE
[WIP] xenstore: client implementation + minor server bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CONFIG_XEN)
 
   add_subdirectory_ifdef(CONFIG_XEN_STORE_COMMON xenstore-common)
   add_subdirectory_ifdef(CONFIG_XEN_STORE_SRV xenstore-srv)
+  add_subdirectory_ifdef(CONFIG_XEN_STORE_CLIENT xenstore-client)
   add_subdirectory_ifdef(CONFIG_XEN_DOMAIN_MANAGEMENT xen-dom-mgmt)
   add_subdirectory_ifdef(CONFIG_XEN_SHELL xen-shell-cmd)
   add_subdirectory_ifdef(CONFIG_XEN_CONSOLE_SRV xen-console-srv)

--- a/Kconfig
+++ b/Kconfig
@@ -23,6 +23,26 @@ config XEN_STORE_SRV_SHELL_CMDS
 	help
 	  Enable shell for XenStore server.
 
+config XEN_STORE_CLIENT
+	bool "Enable XenStore client (frontend)"
+	select XEN_STORE_COMMON
+	help
+	  Enable the xenstore client/frontend library, for a DomU (guest) that
+	  needs to talk to the xenstore server. It maps the guest's own xenstore
+	  ring (HVM_PARAM_STORE_PFN), completes the connection handshake
+	  (RECONNECT -> CONNECTED, as required for dom0less guests whose ring Xen
+	  initialises to XENSTORE_RECONNECT), binds the store event channel
+	  (HVM_PARAM_STORE_EVTCHN) and provides basic read/write transactions.
+
+config XEN_STORE_CLIENT_AUTO_CONNECT
+	bool "Connect the XenStore client automatically at boot"
+	depends on XEN_STORE_CLIENT
+	default y
+	help
+	  Run xs_client_connect() from a SYS_INIT hook at boot. The hook is a
+	  no-op on domains without a provisioned store event channel (e.g. the
+	  xenstore domain itself), so it only acts on real client guests.
+
 config XEN_LIBFDT
 	bool "Enable libfdt support"
 	help

--- a/Kconfig
+++ b/Kconfig
@@ -43,6 +43,35 @@ config XEN_STORE_CLIENT_AUTO_CONNECT
 	  no-op on domains without a provisioned store event channel (e.g. the
 	  xenstore domain itself), so it only acts on real client guests.
 
+config XEN_STORE_CLIENT_MAX_PENDING
+	int "Maximum number of pending XenStore client requests"
+	depends on XEN_STORE_CLIENT
+	default 8
+	range 1 64
+	help
+	  Maximum total number of in-flight requests for this XenStore client.
+	  Additional callers wait until a pending slot is free. Ring writes are
+	  still serialized, but callers do not hold a global request/response
+	  mutex while waiting for replies. Each registered request still uses
+	  the XenStore reply timeout.
+
+config XEN_STORE_CLIENT_RX_STACK_SIZE
+	int "XenStore client RX thread stack size"
+	depends on XEN_STORE_CLIENT
+	default 2048
+	help
+	  Stack size for the XenStore client receive thread that dispatches
+	  replies by request id and handles asynchronous watch events.
+
+config XEN_STORE_CLIENT_RX_PRIORITY
+	int "XenStore client RX thread priority"
+	depends on XEN_STORE_CLIENT
+	default 1
+	help
+	  Priority for the XenStore client receive thread. Keep it preemptible
+	  and below normal application threads because the receive path may poll
+	  the ring when an event-channel notification is missed.
+
 config XEN_LIBFDT
 	bool "Enable libfdt support"
 	help

--- a/Kconfig
+++ b/Kconfig
@@ -55,22 +55,31 @@ config XEN_STORE_CLIENT_MAX_PENDING
 	  mutex while waiting for replies. Each registered request still uses
 	  the XenStore reply timeout.
 
+config XEN_STORE_CLIENT_DEFAULT_TIMEOUT_MS
+	int "Default XenStore client request timeout in milliseconds"
+	depends on XEN_STORE_CLIENT
+	default 5000
+	help
+	  Default timeout used by the simple XenStore client APIs. Timeout
+	  variants can override this per request when an application needs a
+	  shorter probe or a longer boot-time wait.
+
 config XEN_STORE_CLIENT_RX_STACK_SIZE
-	int "XenStore client RX thread stack size"
+	int "XenStore client RX workqueue stack size"
 	depends on XEN_STORE_CLIENT
 	default 2048
 	help
-	  Stack size for the XenStore client receive thread that dispatches
-	  replies by request id and handles asynchronous watch events.
+	  Stack size for the XenStore client workqueue that dispatches replies
+	  by request id and handles asynchronous watch events.
 
 config XEN_STORE_CLIENT_RX_PRIORITY
-	int "XenStore client RX thread priority"
+	int "XenStore client RX workqueue priority"
 	depends on XEN_STORE_CLIENT
-	default 1
+	default 0
 	help
-	  Priority for the XenStore client receive thread. Keep it preemptible
-	  and below normal application threads because the receive path may poll
-	  the ring when an event-channel notification is missed.
+	  Priority for the XenStore client receive workqueue. The default
+	  matches the normal application priority used by the reference
+	  workqueue-based client implementation.
 
 config XEN_LIBFDT
 	bool "Enable libfdt support"

--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -185,6 +185,58 @@ static int allocate_magic_pages(int domid)
 	return rc;
 }
 
+static int allocate_dom0less_xenstore_page(uint32_t domid, uint64_t *max_mem_kb,
+					   xen_pfn_t *store_pfn)
+{
+	const xen_pfn_t xenstore_pfn = XEN_PHYS_PFN(GUEST_MAGIC_BASE) +
+				       XENSTORE_PFN_OFFSET;
+	uint64_t populated_gfn;
+	void *mapped_store;
+	int rc;
+
+	if (!max_mem_kb || !store_pfn) {
+		return -EINVAL;
+	}
+
+	*max_mem_kb += XEN_PAGE_SIZE / 1024;
+	rc = xen_domctl_max_mem(domid, *max_mem_kb);
+	if (rc) {
+		LOG_ERR("dom0less:domid:%u set max memory err (%d)", domid, rc);
+		return rc;
+	}
+
+	populated_gfn = xenmem_populate_physmap(domid, xenstore_pfn,
+						PFN_4K_SHIFT, 1);
+	if (populated_gfn != 1) {
+		LOG_ERR("dom0less:domid:%u populate xenstore page ret=%llu",
+			domid, populated_gfn);
+		return -ENOMEM;
+	}
+
+	rc = xenmem_map_region(domid, 1, xenstore_pfn, &mapped_store);
+	if (rc) {
+		LOG_ERR("dom0less:domid:%u map xenstore page err (%d)", domid, rc);
+		return rc;
+	}
+
+	memset(mapped_store, 0, XEN_PAGE_SIZE);
+	rc = xenmem_cacheflush_mapped_pfns(1, xenstore_pfn);
+	if (rc) {
+		LOG_ERR("dom0less:domid:%u flush xenstore page err (%d)", domid, rc);
+	}
+
+	if (xenmem_unmap_region(1, mapped_store)) {
+		LOG_ERR("dom0less:domid:%u unmap xenstore page err", domid);
+	}
+
+	if (rc) {
+		return rc;
+	}
+
+	*store_pfn = xenstore_pfn;
+	return 0;
+}
+
 /* We need to populate magic pages and memory map here */
 static int prepare_domain_physmap(int domid, uint64_t base_pfn, struct xen_domain_cfg *cfg)
 {
@@ -1025,7 +1077,7 @@ static int dom0less_get_next_domain(uint32_t domid_start, struct xen_domctl_getd
 static int dom0less_init_domain(uint32_t domid, struct xen_domctl_getdomaininfo *infos)
 {
 	struct xen_domain *domain;
-	xen_pfn_t magic_base_pfn;
+	xen_pfn_t store_pfn;
 	uint64_t value;
 	int rc;
 
@@ -1046,10 +1098,11 @@ static int dom0less_init_domain(uint32_t domid, struct xen_domctl_getdomaininfo 
 
 	/*
 	 * Xenstore initialization.
-	 * In dom0less boot case the Xenstore event is already allocated and also allocated
-	 * XEN_MAGIC pages, so Dom0 here should get them and use to init Xenstore.
-	 * At the end Dom0 should set HVM_PARAM_STORE_PFN
-	 * to notify guest domain that Xenstore is ready.
+	 * Xen allocates the event channel for an enhanced dom0less domain.
+	 * Newer Xen can also allocate and publish HVM_PARAM_STORE_PFN during
+	 * domain build. Older Xen leaves HVM_PARAM_STORE_PFN as ~0ULL until
+	 * Dom0 performs the init-dom0less handoff. Zephyr Dom0 does not run
+	 * the Linux helper, so handle both cases here.
 	 */
 	rc = hvm_get_parameter(HVM_PARAM_STORE_EVTCHN, domain->domid, &value);
 	if (rc) {
@@ -1061,23 +1114,30 @@ static int dom0less_init_domain(uint32_t domid, struct xen_domctl_getdomaininfo 
 	LOG_DBG("dom0less: remote_domid=%d, xenstore.remote_evtchn = %d", domain->domid,
 		domain->xenstore.remote_evtchn);
 
-	rc = hvm_get_parameter(HVM_PARAM_MAGIC_BASE_PFN, domid, &magic_base_pfn);
-	if (rc < 0) {
-		LOG_ERR("dom0less:domid:%u Get HVM_PARAM_MAGIC_BASE_PFN err (%d)", domid, rc);
+	rc = hvm_get_parameter(HVM_PARAM_STORE_PFN, domid, &value);
+	if (rc) {
+		LOG_ERR("dom0less:domid:%u Get HVM_PARAM_STORE_PFN err (%d)", domid, rc);
 		goto err_free;
 	}
 
-	LOG_DBG("dom0less:domid:%u MAGIC_BASE_PFN %llx", domid, magic_base_pfn);
-	magic_base_pfn = magic_base_pfn + XENSTORE_PFN_OFFSET;
+	if (value == ~0ULL) {
+		rc = allocate_dom0less_xenstore_page(domid, &domain->max_mem_kb,
+						     &store_pfn);
+		if (rc) {
+			goto err_free;
+		}
+	} else {
+		store_pfn = value;
+	}
 
 	/* init Xenstore */
-	rc = start_domain_stored(domain, magic_base_pfn);
+	rc = start_domain_stored(domain, store_pfn);
 	if (rc) {
 		LOG_ERR("dom0less:domid:%u start Xenstore err (%d)", domid, rc);
 		goto err_free;
 	}
 
-	rc = hvm_set_parameter(HVM_PARAM_STORE_PFN, domid, magic_base_pfn);
+	rc = hvm_set_parameter(HVM_PARAM_STORE_PFN, domid, store_pfn);
 	if (rc) {
 		LOG_ERR("dom0less:domid:%u set HVM_PARAM_STORE_PFN err (%d)", domid, rc);
 		goto err_free_stored;

--- a/xenstore-client/CMakeLists.txt
+++ b/xenstore-client/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 EPAM Systems
+
+add_library(XEN_STORE_CLIENT INTERFACE)
+
+target_include_directories(XEN_STORE_CLIENT INTERFACE include)
+
+zephyr_library()
+zephyr_library_sources(src/xenstore_client.c)
+zephyr_library_link_libraries(XEN_STORE_CLIENT)
+zephyr_include_directories(include)

--- a/xenstore-client/include/xenstore_client.h
+++ b/xenstore-client/include/xenstore_client.h
@@ -20,6 +20,24 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#include <xenstore_common.h>
+
+/**
+ * @brief Watch-event callback called by the XenStore client.
+ *
+ * A watch event is an asynchronous server notification that a watched
+ * XenStore path changed. The callback runs from the client's RX thread, so it
+ * should return quickly and must protect any application-owned shared state
+ * it touches.
+ *
+ * @param path      Changed XenStore path from the event.
+ * @param token     Watch token supplied when the watch was registered.
+ * @param user_data Opaque pointer registered with
+ *                  xs_client_set_watch_callback().
+ */
+typedef void (*xs_client_watch_cb_t)(const char *path, const char *token,
+				     void *user_data);
+
 /**
  * @brief Connect the XenStore client.
  *
@@ -37,6 +55,9 @@ int xs_client_connect(void);
 
 /**
  * @brief Whether the client has completed the connection handshake.
+ *
+ * @retval true  xs_client_connect() completed successfully.
+ * @retval false The client is not connected yet.
  */
 bool xs_client_is_connected(void);
 
@@ -60,5 +81,129 @@ int xs_client_write(const char *path, const char *value);
  * @retval <0  Negative errno (including the server's error reply).
  */
 int xs_client_read(const char *path, char *out, size_t out_len);
+
+/**
+ * @brief List child names under a XenStore path (XS_DIRECTORY).
+ *
+ * The server returns a sequence of NUL-terminated child names. The returned
+ * byte count is the raw payload length, not a string count.
+ *
+ * @param path    Absolute XenStore path.
+ * @param out     Destination buffer for the raw child-name payload.
+ * @param out_len Size of @p out.
+ * @retval >=0    Raw payload byte count.
+ * @retval -EINVAL Invalid argument.
+ * @retval -ENOSPC Destination buffer is too small.
+ * @retval <0     Other negative errno, including the server's error reply.
+ */
+int xs_client_directory(const char *path, char *out, size_t out_len);
+
+/**
+ * @brief Create a XenStore node or directory (XS_MKDIR).
+ *
+ * @param path Absolute XenStore path to create.
+ * @retval 0   Success.
+ * @retval <0  Negative errno, including the server's error reply.
+ */
+int xs_client_mkdir(const char *path);
+
+/**
+ * @brief Remove a XenStore node or subtree (XS_RM).
+ *
+ * @param path Absolute XenStore path to remove.
+ * @retval 0   Success.
+ * @retval <0  Negative errno, including the server's error reply.
+ */
+int xs_client_rm(const char *path);
+
+/**
+ * @brief Read XenStore permissions for a path (XS_GET_PERMS).
+ *
+ * Pass @p perms as NULL to query only the number of permission entries. In
+ * that mode @p num_perms is still required and receives the entry count.
+ *
+ * @param path      Path to inspect.
+ * @param perms     Destination array, or NULL for count-only mode.
+ * @param num_perms In: array capacity. Out: returned permission count.
+ * @retval 0        Success.
+ * @retval -ENOSPC  Destination array is too small; @p num_perms contains the
+ *                  required entry count.
+ * @retval <0       Other negative errno, including the server's error reply.
+ */
+int xs_client_get_perms(const char *path, struct xenstore_perm *perms,
+			size_t *num_perms);
+
+/**
+ * @brief Set XenStore permissions for a path (XS_SET_PERMS).
+ *
+ * @param path      Path whose permissions should be replaced.
+ * @param perms     Permission entries to send to the server.
+ * @param num_perms Number of entries in @p perms.
+ * @retval 0        Success.
+ * @retval -EINVAL  Invalid argument.
+ * @retval -E2BIG   Encoded request does not fit into one XenStore payload.
+ * @retval <0       Other negative errno, including the server's error reply.
+ */
+int xs_client_set_perms(const char *path, const struct xenstore_perm *perms,
+			size_t num_perms);
+
+/**
+ * @brief Register a callback for asynchronous watch events.
+ *
+ * The client keeps one process-wide watch callback. Calling this function
+ * again replaces the previous callback and user_data. The callback runs from
+ * the XenStore client RX thread. The path and token pointers are valid only
+ * until the callback returns.
+ *
+ * When this is called from an application thread, it waits for any currently
+ * running callback to finish before replacing or clearing the callback pair.
+ * When called from the callback itself, it updates the pair immediately to
+ * avoid waiting on the same RX thread that is executing the callback.
+ *
+ * @param cb        Callback to install, or NULL to clear the callback.
+ * @param user_data Opaque pointer passed back to @p cb.
+ */
+void xs_client_set_watch_callback(xs_client_watch_cb_t cb, void *user_data);
+
+/**
+ * @brief Add a XenStore watch (XS_WATCH).
+ *
+ * @param path  Path to watch.
+ * @param token Caller-chosen token returned with matching watch events.
+ * @retval 0    Success.
+ * @retval <0   Negative errno, including the server's error reply.
+ */
+int xs_client_watch(const char *path, const char *token);
+
+/**
+ * @brief Remove a XenStore watch (XS_UNWATCH).
+ *
+ * @param path  Path used when the watch was registered.
+ * @param token Token used when the watch was registered.
+ * @retval 0    Success.
+ * @retval <0   Negative errno, including the server's error reply.
+ */
+int xs_client_unwatch(const char *path, const char *token);
+
+/**
+ * @brief Remove all watches registered by this XenStore connection.
+ *
+ * @retval 0  Success.
+ * @retval <0 Negative errno, including the server's error reply.
+ */
+int xs_client_reset_watches(void);
+
+/**
+ * @brief Return `/local/domain/<domid>` for a domain (XS_GET_DOMAIN_PATH).
+ *
+ * @param domid   Domain id to query.
+ * @param out     Destination buffer for the returned path string.
+ * @param out_len Size of @p out.
+ * @retval >=0    Reply string size including the trailing NUL.
+ * @retval -EINVAL Invalid argument or malformed server reply.
+ * @retval -ENOSPC Destination buffer is too small.
+ * @retval <0     Other negative errno, including the server's error reply.
+ */
+int xs_client_get_domain_path(domid_t domid, char *out, size_t out_len);
 
 #endif /* XENLIB_XENSTORE_CLIENT_H */

--- a/xenstore-client/include/xenstore_client.h
+++ b/xenstore-client/include/xenstore_client.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * XenStore client (frontend) for a Zephyr DomU.
+ *
+ * A dom0less guest is handed a xenstore ring (HVM_PARAM_STORE_PFN) and an
+ * event channel (HVM_PARAM_STORE_EVTCHN) by Xen, with the ring's connection
+ * state initialised to XENSTORE_RECONNECT. Unlike the server side (which lives
+ * in xenstore-srv and only ever sets RECONNECT for dom0less domains), the guest
+ * has to complete the reconnection handshake itself and then it may exchange
+ * requests with the server. This module implements that client half.
+ */
+
+#ifndef XENLIB_XENSTORE_CLIENT_H
+#define XENLIB_XENSTORE_CLIENT_H
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/**
+ * @brief Connect the XenStore client.
+ *
+ * Reads the guest's HVM_PARAM_STORE_PFN / HVM_PARAM_STORE_EVTCHN, maps the
+ * ring, performs the RECONNECT -> CONNECTED handshake and binds the store
+ * event channel. Idempotent: a second call after a successful connect is a
+ * no-op returning 0.
+ *
+ * @retval 0        Connected (or already connected).
+ * @retval -ENODEV  No store ring/evtchn provisioned for this domain
+ *                  (e.g. this is the xenstore domain, not a client).
+ * @retval <0       Other negative errno on failure.
+ */
+int xs_client_connect(void);
+
+/**
+ * @brief Whether the client has completed the connection handshake.
+ */
+bool xs_client_is_connected(void);
+
+/**
+ * @brief Write a value to a XenStore path (XS_WRITE).
+ *
+ * @param path  Absolute XenStore path.
+ * @param value NUL-terminated value to store.
+ * @retval 0   Success.
+ * @retval <0  Negative errno (including the server's error reply).
+ */
+int xs_client_write(const char *path, const char *value);
+
+/**
+ * @brief Read a value from a XenStore path (XS_READ).
+ *
+ * @param path    Absolute XenStore path.
+ * @param out     Destination buffer (NUL-terminated on success).
+ * @param out_len Size of @p out.
+ * @retval >=0 Number of payload bytes returned by the server.
+ * @retval <0  Negative errno (including the server's error reply).
+ */
+int xs_client_read(const char *path, char *out, size_t out_len);
+
+#endif /* XENLIB_XENSTORE_CLIENT_H */

--- a/xenstore-client/include/xenstore_client.h
+++ b/xenstore-client/include/xenstore_client.h
@@ -20,14 +20,17 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#include <zephyr/kernel.h>
+#include <zephyr/sys/slist.h>
+
 #include <xenstore_common.h>
 
 /**
  * @brief Watch-event callback called by the XenStore client.
  *
  * A watch event is an asynchronous server notification that a watched
- * XenStore path changed. The callback runs from the client's RX thread, so it
- * should return quickly and must protect any application-owned shared state
+ * XenStore path changed. The callback runs from the client's RX workqueue, so
+ * it should return quickly and must protect any application-owned shared state
  * it touches.
  *
  * @param path      Changed XenStore path from the event.
@@ -37,6 +40,28 @@
  */
 typedef void (*xs_client_watch_cb_t)(const char *path, const char *token,
 				     void *user_data);
+
+/**
+ * @brief Application-owned XenStore watcher descriptor.
+ *
+ * XenStore watch events arrive as wire data: changed path plus the token that
+ * was used when the watch was registered. The descriptor is the client-side
+ * routing record that maps such an event back to one application callback.
+ *
+ * The descriptor storage is owned by the application and must remain valid
+ * until xs_client_watcher_unregister() returns. Fields are public so callers
+ * can allocate the structure statically, but they are maintained by the
+ * XenStore client and should not be modified directly.
+ */
+struct xs_client_watcher {
+	sys_snode_t node;        /** Internal link in the watcher list. */
+	const char *path;        /** Watched path supplied at registration. */
+	const char *token;       /** Token used to route matching watch events. */
+	xs_client_watch_cb_t cb; /** Callback invoked for matching events. */
+	void *user_data;         /** Opaque pointer passed back to @p cb. */
+	bool active;             /** Internal flag: descriptor is registered. */
+	bool running;            /** Internal flag: callback is currently running. */
+};
 
 /**
  * @brief Connect the XenStore client.
@@ -62,6 +87,24 @@ int xs_client_connect(void);
 bool xs_client_is_connected(void);
 
 /**
+ * @brief Replace the default timeout used by simple XenStore client APIs.
+ *
+ * The simple APIs such as xs_client_read() use this timeout for both request
+ * ring waits and the final reply wait. Timeout-specific APIs bypass this
+ * default for one call.
+ *
+ * @param timeout New default timeout.
+ */
+void xs_client_set_default_timeout(k_timeout_t timeout);
+
+/**
+ * @brief Return the current default XenStore client timeout.
+ *
+ * @return Timeout used by simple APIs.
+ */
+k_timeout_t xs_client_get_default_timeout(void);
+
+/**
  * @brief Write a value to a XenStore path (XS_WRITE).
  *
  * @param path  Absolute XenStore path.
@@ -70,6 +113,18 @@ bool xs_client_is_connected(void);
  * @retval <0  Negative errno (including the server's error reply).
  */
 int xs_client_write(const char *path, const char *value);
+
+/**
+ * @brief Write a value using a caller-supplied timeout.
+ *
+ * @param path    Absolute XenStore path.
+ * @param value   NUL-terminated value to store.
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval 0      Success.
+ * @retval <0     Negative errno.
+ */
+int xs_client_write_timeout(const char *path, const char *value,
+			    k_timeout_t timeout);
 
 /**
  * @brief Read a value from a XenStore path (XS_READ).
@@ -81,6 +136,19 @@ int xs_client_write(const char *path, const char *value);
  * @retval <0  Negative errno (including the server's error reply).
  */
 int xs_client_read(const char *path, char *out, size_t out_len);
+
+/**
+ * @brief Read a value using a caller-supplied timeout.
+ *
+ * @param path    Absolute XenStore path.
+ * @param out     Destination buffer (NUL-terminated on success).
+ * @param out_len Size of @p out.
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval >=0    Number of payload bytes returned by the server.
+ * @retval <0     Negative errno.
+ */
+int xs_client_read_timeout(const char *path, char *out, size_t out_len,
+			   k_timeout_t timeout);
 
 /**
  * @brief List child names under a XenStore path (XS_DIRECTORY).
@@ -99,6 +167,19 @@ int xs_client_read(const char *path, char *out, size_t out_len);
 int xs_client_directory(const char *path, char *out, size_t out_len);
 
 /**
+ * @brief List child names using a caller-supplied timeout.
+ *
+ * @param path    Absolute XenStore path.
+ * @param out     Destination buffer for the raw child-name payload.
+ * @param out_len Size of @p out.
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval >=0    Raw payload byte count.
+ * @retval <0     Negative errno.
+ */
+int xs_client_directory_timeout(const char *path, char *out, size_t out_len,
+				k_timeout_t timeout);
+
+/**
  * @brief Create a XenStore node or directory (XS_MKDIR).
  *
  * @param path Absolute XenStore path to create.
@@ -108,6 +189,16 @@ int xs_client_directory(const char *path, char *out, size_t out_len);
 int xs_client_mkdir(const char *path);
 
 /**
+ * @brief Create a XenStore node or directory using a caller-supplied timeout.
+ *
+ * @param path    Absolute XenStore path to create.
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval 0      Success.
+ * @retval <0     Negative errno.
+ */
+int xs_client_mkdir_timeout(const char *path, k_timeout_t timeout);
+
+/**
  * @brief Remove a XenStore node or subtree (XS_RM).
  *
  * @param path Absolute XenStore path to remove.
@@ -115,6 +206,16 @@ int xs_client_mkdir(const char *path);
  * @retval <0  Negative errno, including the server's error reply.
  */
 int xs_client_rm(const char *path);
+
+/**
+ * @brief Remove a XenStore node or subtree using a caller-supplied timeout.
+ *
+ * @param path    Absolute XenStore path to remove.
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval 0      Success.
+ * @retval <0     Negative errno.
+ */
+int xs_client_rm_timeout(const char *path, k_timeout_t timeout);
 
 /**
  * @brief Read XenStore permissions for a path (XS_GET_PERMS).
@@ -134,6 +235,19 @@ int xs_client_get_perms(const char *path, struct xenstore_perm *perms,
 			size_t *num_perms);
 
 /**
+ * @brief Read XenStore permissions using a caller-supplied timeout.
+ *
+ * @param path      Path to inspect.
+ * @param perms     Destination array, or NULL for count-only mode.
+ * @param num_perms In: array capacity. Out: returned permission count.
+ * @param timeout   Timeout for request-ring waits and the matching reply.
+ * @retval 0        Success.
+ * @retval <0       Negative errno.
+ */
+int xs_client_get_perms_timeout(const char *path, struct xenstore_perm *perms,
+				size_t *num_perms, k_timeout_t timeout);
+
+/**
  * @brief Set XenStore permissions for a path (XS_SET_PERMS).
  *
  * @param path      Path whose permissions should be replaced.
@@ -148,22 +262,75 @@ int xs_client_set_perms(const char *path, const struct xenstore_perm *perms,
 			size_t num_perms);
 
 /**
+ * @brief Set XenStore permissions using a caller-supplied timeout.
+ *
+ * @param path      Path whose permissions should be replaced.
+ * @param perms     Permission entries to send to the server.
+ * @param num_perms Number of entries in @p perms.
+ * @param timeout   Timeout for request-ring waits and the matching reply.
+ * @retval 0        Success.
+ * @retval <0       Negative errno.
+ */
+int xs_client_set_perms_timeout(const char *path,
+				const struct xenstore_perm *perms,
+				size_t num_perms, k_timeout_t timeout);
+
+/**
  * @brief Register a callback for asynchronous watch events.
  *
  * The client keeps one process-wide watch callback. Calling this function
  * again replaces the previous callback and user_data. The callback runs from
- * the XenStore client RX thread. The path and token pointers are valid only
- * until the callback returns.
+ * the XenStore client RX workqueue. The path and token pointers are valid
+ * only until the callback returns.
  *
  * When this is called from an application thread, it waits for any currently
  * running callback to finish before replacing or clearing the callback pair.
  * When called from the callback itself, it updates the pair immediately to
- * avoid waiting on the same RX thread that is executing the callback.
+ * avoid waiting on the same workqueue thread that is executing the callback.
  *
  * @param cb        Callback to install, or NULL to clear the callback.
  * @param user_data Opaque pointer passed back to @p cb.
  */
 void xs_client_set_watch_callback(xs_client_watch_cb_t cb, void *user_data);
+
+/**
+ * @brief Register one routed watcher descriptor.
+ *
+ * This combines client-side callback registration with the XS_WATCH request
+ * sent to the server. Events are routed to @p watcher when the event token
+ * matches @p token and the event path belongs under @p path.
+ *
+ * @param watcher   Application-owned descriptor storage.
+ * @param path      Path to watch.
+ * @param token     Caller-chosen token returned with matching watch events.
+ * @param cb        Callback invoked for matching events.
+ * @param user_data Opaque pointer passed back to @p cb.
+ * @retval 0        Success.
+ * @retval -EALREADY Descriptor is already registered.
+ * @retval <0       Negative errno.
+ */
+int xs_client_watcher_register(struct xs_client_watcher *watcher,
+			       const char *path, const char *token,
+			       xs_client_watch_cb_t cb, void *user_data);
+
+/**
+ * @brief Unregister one routed watcher descriptor.
+ *
+ * An application thread waits for an in-flight callback using this descriptor
+ * to finish, removes the descriptor from local routing, and sends XS_UNWATCH
+ * to the server. Calling this from the workqueue callback cannot send the
+ * blocking XS_UNWATCH request and cannot wait for the same callback to finish;
+ * in that case the function returns -EWOULDBLOCK without changing the
+ * descriptor.
+ *
+ * @param watcher Descriptor previously registered with
+ *                xs_client_watcher_register().
+ * @retval 0      Success.
+ * @retval -ENOENT Descriptor is not registered.
+ * @retval -EWOULDBLOCK Called from this descriptor's workqueue callback.
+ * @retval <0     Negative errno.
+ */
+int xs_client_watcher_unregister(struct xs_client_watcher *watcher);
 
 /**
  * @brief Add a XenStore watch (XS_WATCH).
@@ -176,6 +343,18 @@ void xs_client_set_watch_callback(xs_client_watch_cb_t cb, void *user_data);
 int xs_client_watch(const char *path, const char *token);
 
 /**
+ * @brief Add a XenStore watch using a caller-supplied timeout.
+ *
+ * @param path    Path to watch.
+ * @param token   Caller-chosen token returned with matching watch events.
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval 0      Success.
+ * @retval <0     Negative errno.
+ */
+int xs_client_watch_timeout(const char *path, const char *token,
+			    k_timeout_t timeout);
+
+/**
  * @brief Remove a XenStore watch (XS_UNWATCH).
  *
  * @param path  Path used when the watch was registered.
@@ -186,12 +365,33 @@ int xs_client_watch(const char *path, const char *token);
 int xs_client_unwatch(const char *path, const char *token);
 
 /**
+ * @brief Remove a XenStore watch using a caller-supplied timeout.
+ *
+ * @param path    Path used when the watch was registered.
+ * @param token   Token used when the watch was registered.
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval 0      Success.
+ * @retval <0     Negative errno.
+ */
+int xs_client_unwatch_timeout(const char *path, const char *token,
+			      k_timeout_t timeout);
+
+/**
  * @brief Remove all watches registered by this XenStore connection.
  *
  * @retval 0  Success.
  * @retval <0 Negative errno, including the server's error reply.
  */
 int xs_client_reset_watches(void);
+
+/**
+ * @brief Remove all watches using a caller-supplied timeout.
+ *
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval 0      Success.
+ * @retval <0     Negative errno.
+ */
+int xs_client_reset_watches_timeout(k_timeout_t timeout);
 
 /**
  * @brief Return `/local/domain/<domid>` for a domain (XS_GET_DOMAIN_PATH).
@@ -205,5 +405,18 @@ int xs_client_reset_watches(void);
  * @retval <0     Other negative errno, including the server's error reply.
  */
 int xs_client_get_domain_path(domid_t domid, char *out, size_t out_len);
+
+/**
+ * @brief Return a domain path using a caller-supplied timeout.
+ *
+ * @param domid   Domain id to query.
+ * @param out     Destination buffer for the returned path string.
+ * @param out_len Size of @p out.
+ * @param timeout Timeout for request-ring waits and the matching reply.
+ * @retval >=0    Reply string size including the trailing NUL.
+ * @retval <0     Negative errno.
+ */
+int xs_client_get_domain_path_timeout(domid_t domid, char *out, size_t out_len,
+				      k_timeout_t timeout);
 
 #endif /* XENLIB_XENSTORE_CLIENT_H */

--- a/xenstore-client/src/xenstore_client.c
+++ b/xenstore-client/src/xenstore_client.c
@@ -29,20 +29,60 @@
 LOG_MODULE_REGISTER(xenstore_client);
 
 #define XS_REPLY_TIMEOUT K_MSEC(5000)
+#define XS_RING_POLL_SPINS 16
+
+/*
+ * One in-flight XenStore request.
+ *
+ * A caller thread creates this ticket before it writes a request into the
+ * shared XenStore ring. The RX thread later reads replies from that same ring,
+ * finds the ticket by req_id, copies the matching reply here, and wakes the
+ * caller through done.
+ */
+struct xs_pending_req {
+	sys_snode_t node;          /* Link in the global pending-request list. */
+	struct k_sem done;         /* Caller waits here until RX completes this request. */
+	struct xsd_sockmsg hdr;    /* Reply header copied from the XenStore ring. */
+	uint32_t req_id;           /* Wire id used to match a reply to this request. */
+	int rc;                    /* Local transport error, or 0 when a reply arrived. */
+	size_t payload_len;        /* Number of valid reply bytes in payload. */
+	char payload[XENSTORE_PAYLOAD_MAX]; /* Reply body copied by the RX thread. */
+};
 
 static struct xenstore_domain_interface *xs_intf;
 static evtchn_port_t xs_evtchn;
-static struct k_sem xs_event_sem;
+/* RX waits on this when the response ring is empty. */
+static struct k_sem xs_rx_sem;
+/* TX waits on this when the request ring is full. */
+static struct k_sem xs_tx_sem;
+/* Counts free request tickets; callers wait here when all tickets are busy. */
+static struct k_sem xs_pending_slots;
 /* Serializes connection setup so only one RX thread/ring binding is created. */
 static K_MUTEX_DEFINE(xs_connect_lock);
-static struct k_mutex xs_lock;
+/* Serializes bytes written by callers into the shared request ring. */
+static struct k_mutex xs_tx_lock;
+/* Protects the pending-request list and ticket completion/removal. */
+static struct k_mutex xs_pending_lock;
+/* All requests that have been sent or are being sent and still need a reply. */
+static sys_slist_t xs_pending_reqs;
+/* Next wire request id; replies carry this id back for ticket matching. */
 static uint32_t xs_req_id;
+/* True after the XenStore page is mapped and the event channel is bound. */
 static bool xs_connected;
+
+static void xs_rx_thread_fn(void *p1, void *p2, void *p3);
+static struct k_thread xs_rx_thread;
+static K_THREAD_STACK_DEFINE(xs_rx_stack, CONFIG_XEN_STORE_CLIENT_RX_STACK_SIZE);
+
+/* RX scratch buffer used before a reply is copied into a request ticket. */
+static char xs_rx_payload[XENSTORE_PAYLOAD_MAX];
 
 static void xs_event_cb(void *priv)
 {
 	ARG_UNUSED(priv);
-	k_sem_give(&xs_event_sem);
+	/* One Xen doorbell can mean either new replies or freed request space. */
+	k_sem_give(&xs_rx_sem);
+	k_sem_give(&xs_tx_sem);
 }
 
 int xs_client_connect(void)
@@ -72,8 +112,13 @@ int xs_client_connect(void)
 		goto out_unlock;
 	}
 
-	k_sem_init(&xs_event_sem, 0, 1);
-	k_mutex_init(&xs_lock);
+	k_sem_init(&xs_rx_sem, 0, 1);
+	k_sem_init(&xs_tx_sem, 0, 1);
+	k_sem_init(&xs_pending_slots, CONFIG_XEN_STORE_CLIENT_MAX_PENDING,
+		   CONFIG_XEN_STORE_CLIENT_MAX_PENDING);
+	k_mutex_init(&xs_tx_lock);
+	k_mutex_init(&xs_pending_lock);
+	sys_slist_init(&xs_pending_reqs);
 
 	/* Map the guest's own xenstore ring page. */
 	device_map(&va, (uintptr_t)(store_pfn << XEN_PAGE_SHIFT), XEN_PAGE_SIZE,
@@ -105,6 +150,9 @@ int xs_client_connect(void)
 	}
 
 	xs_connected = true;
+	k_thread_create(&xs_rx_thread, xs_rx_stack, K_THREAD_STACK_SIZEOF(xs_rx_stack),
+			xs_rx_thread_fn, NULL, NULL, NULL,
+			CONFIG_XEN_STORE_CLIENT_RX_PRIORITY, 0, K_NO_WAIT);
 	LOG_INF("xenstore client connected (gfn 0x%llx, evtchn %u)",
 		store_pfn, xs_evtchn);
 	rc = 0;
@@ -125,7 +173,14 @@ bool xs_client_is_connected(void)
 	return connected;
 }
 
-/* Write @len bytes to the request ring, draining via the event channel. */
+/*
+ * Copy exactly len request bytes from buf into the XenStore request ring.
+ *
+ * The request ring is a small shared byte queue from client to server. If it
+ * is full, this helper rings the server doorbell and waits on xs_tx_sem until
+ * an event suggests the server may have consumed bytes. On success it returns
+ * len. On ring/write/wait failure it returns a negative errno.
+ */
 static int xs_write_all(const void *buf, size_t len)
 {
 	const uint8_t *p = buf;
@@ -139,7 +194,7 @@ static int xs_write_all(const void *buf, size_t len)
 		}
 		if (w == 0) {
 			notify_evtchn(xs_evtchn);
-			if (k_sem_take(&xs_event_sem, XS_REPLY_TIMEOUT) != 0) {
+			if (k_sem_take(&xs_tx_sem, XS_REPLY_TIMEOUT) != 0) {
 				return -ETIMEDOUT;
 			}
 			continue;
@@ -150,7 +205,14 @@ static int xs_write_all(const void *buf, size_t len)
 	return (int)len;
 }
 
-/* Read @len bytes from the response ring, waiting via the event channel. */
+/*
+ * Copy up to len currently available response bytes from the XenStore ring.
+ *
+ * This helper is intentionally non-blocking for "no bytes available". The RX
+ * thread is the only response-ring reader, and xs_read_full() owns the waiting
+ * policy. A positive return can therefore be a short read, zero means the ring
+ * had no more bytes right now, and a negative value is a ring read error.
+ */
 static int xs_read_all(void *buf, size_t len)
 {
 	uint8_t *p = buf;
@@ -164,86 +226,292 @@ static int xs_read_all(void *buf, size_t len)
 			return r;
 		}
 		if (r == 0) {
-			if (k_sem_take(&xs_event_sem, XS_REPLY_TIMEOUT) != 0) {
-				return -ETIMEDOUT;
-			}
-			continue;
+			return (int)off;
 		}
 		off += r;
-		/* We freed ring space; let the server know. */
 		notify_evtchn(xs_evtchn);
 	}
 	return (int)len;
 }
 
-/* One synchronous request/response exchange. */
-static int xs_talk(uint32_t type, const void *payload, size_t payload_len,
-		   char *out, size_t out_len)
+/*
+ * Wait until exactly len response bytes have been consumed.
+ *
+ * The RX thread uses this when it needs a complete XenStore header or payload
+ * before dispatching a message. If buf is NULL, bytes are discarded; this is
+ * used to drain an oversized payload so the next message starts at a clean
+ * ring position. On success it returns len, otherwise a negative errno.
+ */
+static int xs_read_full(void *buf, size_t len)
+{
+	uint8_t *p = buf;
+	size_t off = 0;
+
+	while (off < len) {
+		int r = xs_read_all(p ? p + off : NULL, len - off);
+
+		if (r < 0) {
+			return r;
+		}
+		if (r == 0) {
+			notify_evtchn(xs_evtchn);
+			for (int i = 0; i < XS_RING_POLL_SPINS; i++) {
+				k_busy_wait(50);
+				r = xs_read_all(p ? p + off : NULL, len - off);
+				if (r != 0) {
+					break;
+				}
+			}
+			if (r == 0) {
+				k_yield();
+				continue;
+			}
+			if (r < 0) {
+				return r;
+			}
+		}
+		off += r;
+	}
+	return (int)len;
+}
+
+/*
+ * Find the pending ticket for one wire request id.
+ *
+ * The caller must already hold xs_pending_lock because the pending list is
+ * shared by caller threads and the RX thread. When prev is not NULL, it is
+ * filled with the previous list node so sys_slist_remove() can unlink the
+ * found ticket from Zephyr's singly linked list.
+ */
+static struct xs_pending_req *xs_find_pending_locked(uint32_t req_id,
+						    sys_snode_t **prev)
+{
+	sys_snode_t *prev_node = NULL;
+	struct xs_pending_req *req;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&xs_pending_reqs, req, node) {
+		if (req->req_id == req_id) {
+			if (prev) {
+				*prev = prev_node;
+			}
+			return req;
+		}
+		prev_node = &req->node;
+	}
+
+	return NULL;
+}
+
+/*
+ * Finish one normal server reply and wake the waiting caller.
+ *
+ * The RX thread calls this after it has read a full XenStore reply. The reply
+ * still lives in the RX scratch buffer, so this helper finds the caller's
+ * pending ticket by req_id, copies the reply into that ticket, returns the
+ * pending slot, and gives req->done so the caller can continue.
+ */
+static void xs_complete_request(struct xsd_sockmsg *hdr, const char *payload,
+				size_t payload_len)
+{
+	sys_snode_t *prev = NULL;
+	struct xs_pending_req *req;
+
+	k_mutex_lock(&xs_pending_lock, K_FOREVER);
+	req = xs_find_pending_locked(hdr->req_id, &prev);
+	if (!req) {
+		k_mutex_unlock(&xs_pending_lock);
+		LOG_WRN("unexpected xenstore reply req_id=%u type=%u",
+			hdr->req_id, hdr->type);
+		return;
+	}
+
+	sys_slist_remove(&xs_pending_reqs, prev, &req->node);
+	k_sem_give(&xs_pending_slots);
+	req->hdr = *hdr;
+	req->payload_len = payload_len;
+	memcpy(req->payload, payload, payload_len);
+	req->rc = 0;
+	k_sem_give(&req->done);
+	k_mutex_unlock(&xs_pending_lock);
+}
+
+/*
+ * Finish one pending request with a local client-side error.
+ *
+ * This is used when the client cannot finish the transport work for a request:
+ * for example, a ring read/write fails or the server advertises a payload that
+ * does not fit in the RX buffer. There may already be a caller sleeping on the
+ * request ticket, so the helper records rc and wakes that caller the same way
+ * a normal reply would.
+ */
+static void xs_complete_request_error(uint32_t req_id, int rc)
+{
+	sys_snode_t *prev = NULL;
+	struct xs_pending_req *req;
+
+	k_mutex_lock(&xs_pending_lock, K_FOREVER);
+	req = xs_find_pending_locked(req_id, &prev);
+	if (req) {
+		sys_slist_remove(&xs_pending_reqs, prev, &req->node);
+		k_sem_give(&xs_pending_slots);
+		req->rc = rc;
+		k_sem_give(&req->done);
+	}
+	k_mutex_unlock(&xs_pending_lock);
+}
+
+/*
+ * Single reader for the XenStore response ring.
+ *
+ * The response ring is one shared incoming byte stream. Application callers do
+ * not read it directly; otherwise one caller could consume another caller's
+ * reply. This thread reads each message, handles watch events immediately, and
+ * routes normal replies to the matching pending request by req_id.
+ */
+static void xs_rx_thread_fn(void *p1, void *p2, void *p3)
 {
 	struct xsd_sockmsg hdr;
-	char tmp[XENSTORE_PAYLOAD_MAX];
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	while (true) {
+		int rc;
+
+		rc = xs_read_full(&hdr, sizeof(hdr));
+		if (rc < 0) {
+			LOG_ERR("xenstore response header read failed (%d)", rc);
+			continue;
+		}
+
+		if (hdr.len > sizeof(xs_rx_payload)) {
+			(void)xs_read_full(NULL, hdr.len);
+			xs_complete_request_error(hdr.req_id, -E2BIG);
+			continue;
+		}
+
+		rc = xs_read_full(xs_rx_payload, hdr.len);
+		if (rc < 0) {
+			xs_complete_request_error(hdr.req_id, rc);
+			continue;
+		}
+
+		if (hdr.type == XS_WATCH_EVENT) {
+			LOG_DBG("unexpected xenstore watch event");
+			k_yield();
+			continue;
+		}
+
+		xs_complete_request(&hdr, xs_rx_payload, hdr.len);
+		k_yield();
+	}
+}
+
+/*
+ * Send one XenStore request and wait for the matching reply.
+ *
+ * The caller takes a pending slot, creates a request ticket, registers it by a
+ * fresh req_id, and writes the request header/payload under xs_tx_lock so bytes
+ * from concurrent callers cannot interleave. After the write, the caller does
+ * not read the response ring; it sleeps on its own ticket until the RX thread
+ * completes it or XS_REPLY_TIMEOUT expires.
+ */
+static int xs_talk(uint32_t type, uint32_t tx_id, const void *payload,
+		   size_t payload_len, char *out, size_t out_len)
+{
+	struct xs_pending_req *req;
+	struct xsd_sockmsg hdr;
 	size_t plen;
 	int rc;
 
 	if (!xs_connected) {
 		return -ENOTCONN;
 	}
+	if (payload_len > XENSTORE_PAYLOAD_MAX) {
+		return -E2BIG;
+	}
 
-	k_mutex_lock(&xs_lock, K_FOREVER);
+	k_sem_take(&xs_pending_slots, K_FOREVER);
+	req = k_malloc(sizeof(*req));
+	if (!req) {
+		k_sem_give(&xs_pending_slots);
+		return -ENOMEM;
+	}
+	k_sem_init(&req->done, 0, 1);
+	req->rc = -EIO;
+	req->payload_len = 0;
 
 	hdr.type = type;
-	hdr.req_id = ++xs_req_id;
-	hdr.tx_id = 0;
+	hdr.tx_id = tx_id;
 	hdr.len = (uint32_t)payload_len;
 
+	k_mutex_lock(&xs_pending_lock, K_FOREVER);
+	hdr.req_id = ++xs_req_id;
+	req->req_id = hdr.req_id;
+	sys_slist_append(&xs_pending_reqs, &req->node);
+	k_mutex_unlock(&xs_pending_lock);
+
+	k_mutex_lock(&xs_tx_lock, K_FOREVER);
 	rc = xs_write_all(&hdr, sizeof(hdr));
 	if (rc < 0) {
-		goto out_unlock;
+		k_mutex_unlock(&xs_tx_lock);
+		xs_complete_request_error(req->req_id, rc);
+		goto wait_done;
 	}
 	if (payload_len) {
 		rc = xs_write_all(payload, payload_len);
 		if (rc < 0) {
-			goto out_unlock;
+			k_mutex_unlock(&xs_tx_lock);
+			xs_complete_request_error(req->req_id, rc);
+			goto wait_done;
 		}
 	}
+	notify_evtchn(xs_evtchn);
+	k_mutex_unlock(&xs_tx_lock);
 
-	rc = xs_read_all(&hdr, sizeof(hdr));
-	if (rc < 0) {
-		goto out_unlock;
+wait_done:
+	if (k_sem_take(&req->done, XS_REPLY_TIMEOUT) != 0) {
+		sys_snode_t *prev = NULL;
+
+		k_mutex_lock(&xs_pending_lock, K_FOREVER);
+		if (xs_find_pending_locked(req->req_id, &prev)) {
+			sys_slist_remove(&xs_pending_reqs, prev, &req->node);
+			k_sem_give(&xs_pending_slots);
+		}
+		k_mutex_unlock(&xs_pending_lock);
+		k_free(req);
+		return -ETIMEDOUT;
 	}
 
-	plen = hdr.len;
-	if (plen > sizeof(tmp)) {
-		plen = sizeof(tmp);
-	}
-	rc = xs_read_all(tmp, plen);
-	if (rc < 0) {
-		goto out_unlock;
+	if (req->rc < 0) {
+		rc = req->rc;
+		k_free(req);
+		return rc;
 	}
 
-	if (hdr.type == XS_ERROR) {
-		int e = xenstore_get_error(tmp, plen);
+	plen = req->payload_len;
+	if (req->hdr.type == XS_ERROR) {
+		int e = xenstore_get_error(req->payload, plen);
 
 		rc = e ? -e : -EIO;
-		goto out_unlock;
+		k_free(req);
+		return rc;
 	}
 
 	if (out && out_len) {
-		size_t n = plen < out_len ? plen : out_len - 1;
+		size_t n = plen < out_len ? plen : out_len;
 
-		memcpy(out, tmp, n);
-		out[n] = '\0';
+		memcpy(out, req->payload, n);
 	}
-	rc = (int)plen;
 
-out_unlock:
-	k_mutex_unlock(&xs_lock);
-	return rc;
+	k_free(req);
+	return (int)plen;
 }
 
 int xs_client_write(const char *path, const char *value)
 {
-	char buf[XENSTORE_ABS_PATH_MAX + XENSTORE_PAYLOAD_MAX];
+	char *buf;
 	size_t pl, vl;
 	int rc;
 
@@ -252,23 +520,45 @@ int xs_client_write(const char *path, const char *value)
 	}
 	pl = strlen(path) + 1;
 	vl = strlen(value);
-	if (pl + vl > sizeof(buf)) {
+	if (pl + vl > XENSTORE_PAYLOAD_MAX) {
 		return -E2BIG;
+	}
+
+	buf = k_malloc(XENSTORE_PAYLOAD_MAX);
+	if (!buf) {
+		return -ENOMEM;
 	}
 
 	memcpy(buf, path, pl);           /* path + NUL */
 	memcpy(buf + pl, value, vl);     /* value (no trailing NUL) */
 
-	rc = xs_talk(XS_WRITE, buf, pl + vl, NULL, 0);
+	rc = xs_talk(XS_WRITE, 0, buf, pl + vl, NULL, 0);
+	k_free(buf);
 	return rc < 0 ? rc : 0;
 }
 
 int xs_client_read(const char *path, char *out, size_t out_len)
 {
+	int rc;
+
 	if (!path) {
 		return -EINVAL;
 	}
-	return xs_talk(XS_READ, path, strlen(path) + 1, out, out_len);
+	if (!out || out_len == 0) {
+		return -EINVAL;
+	}
+
+	rc = xs_talk(XS_READ, 0, path, strlen(path) + 1, out, out_len);
+	if (rc < 0) {
+		return rc;
+	}
+	if ((size_t)rc >= out_len) {
+		out[out_len - 1] = '\0';
+		return -ENOSPC;
+	}
+
+	out[rc] = '\0';
+	return rc;
 }
 
 #ifdef CONFIG_XEN_STORE_CLIENT_AUTO_CONNECT

--- a/xenstore-client/src/xenstore_client.c
+++ b/xenstore-client/src/xenstore_client.c
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2025 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * XenStore client (frontend) for a Zephyr DomU. See xenstore_client.h.
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/barrier.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/xen/public/xen.h>
+#include <zephyr/xen/public/hvm/params.h>
+#include <zephyr/xen/generic.h>
+#include <zephyr/xen/hvm.h>
+#include <zephyr/xen/events.h>
+
+#include <xen/public/io/xs_wire.h>
+#include <xenstore_common.h>
+
+#include "xenstore_client.h"
+
+LOG_MODULE_REGISTER(xenstore_client);
+
+#define XS_REPLY_TIMEOUT K_MSEC(5000)
+
+static struct xenstore_domain_interface *xs_intf;
+static evtchn_port_t xs_evtchn;
+static struct k_sem xs_event_sem;
+/* Serializes connection setup so only one RX thread/ring binding is created. */
+static K_MUTEX_DEFINE(xs_connect_lock);
+static struct k_mutex xs_lock;
+static uint32_t xs_req_id;
+static bool xs_connected;
+
+static void xs_event_cb(void *priv)
+{
+	ARG_UNUSED(priv);
+	k_sem_give(&xs_event_sem);
+}
+
+int xs_client_connect(void)
+{
+	uint64_t store_pfn = 0, store_evtchn = 0;
+	mm_reg_t va;
+	int rc;
+
+	k_mutex_lock(&xs_connect_lock, K_FOREVER);
+
+	if (xs_connected) {
+		rc = 0;
+		goto out_unlock;
+	}
+
+	rc = hvm_get_parameter(HVM_PARAM_STORE_PFN, DOMID_SELF, &store_pfn);
+	if (rc || store_pfn == 0 || !~store_pfn) {
+		rc = rc ? rc : -ENODEV;
+		goto out_unlock;
+	}
+	rc = hvm_get_parameter(HVM_PARAM_STORE_EVTCHN, DOMID_SELF, &store_evtchn);
+	if (rc || store_evtchn == 0) {
+		/* No event channel: this domain is not a xenstore client
+		 * (e.g. it is the xenstore domain itself).
+		 */
+		rc = rc ? rc : -ENODEV;
+		goto out_unlock;
+	}
+
+	k_sem_init(&xs_event_sem, 0, 1);
+	k_mutex_init(&xs_lock);
+
+	/* Map the guest's own xenstore ring page. */
+	device_map(&va, (uintptr_t)(store_pfn << XEN_PAGE_SHIFT), XEN_PAGE_SIZE,
+		   K_MEM_CACHE_NONE);
+	xs_intf = (struct xenstore_domain_interface *)va;
+
+	/* Attach a handler to the (Xen-provisioned) store event channel. */
+	rc = bind_event_channel((evtchn_port_t)store_evtchn, xs_event_cb, NULL);
+	if (rc < 0) {
+		LOG_ERR("bind store evtchn %llu failed (%d)", store_evtchn, rc);
+		goto out_unlock;
+	}
+	xs_evtchn = (evtchn_port_t)store_evtchn;
+	unmask_event_channel(xs_evtchn);
+
+	/*
+	 * Reconnection handshake. Xen initialises a dom0less client's ring to
+	 * XENSTORE_RECONNECT; the frontend resets the ring indexes and marks it
+	 * CONNECTED to signal the server it is ready. (For a ring Xen already
+	 * left CONNECTED there is nothing to do.)
+	 */
+	if (xs_intf->connection == XENSTORE_RECONNECT) {
+		xs_intf->req_cons = xs_intf->req_prod = 0;
+		xs_intf->rsp_cons = xs_intf->rsp_prod = 0;
+		z_barrier_dmem_fence_full();
+		xs_intf->connection = XENSTORE_CONNECTED;
+		z_barrier_dmem_fence_full();
+		notify_evtchn(xs_evtchn);
+	}
+
+	xs_connected = true;
+	LOG_INF("xenstore client connected (gfn 0x%llx, evtchn %u)",
+		store_pfn, xs_evtchn);
+	rc = 0;
+
+out_unlock:
+	k_mutex_unlock(&xs_connect_lock);
+	return rc;
+}
+
+bool xs_client_is_connected(void)
+{
+	bool connected;
+
+	k_mutex_lock(&xs_connect_lock, K_FOREVER);
+	connected = xs_connected;
+	k_mutex_unlock(&xs_connect_lock);
+
+	return connected;
+}
+
+/* Write @len bytes to the request ring, draining via the event channel. */
+static int xs_write_all(const void *buf, size_t len)
+{
+	const uint8_t *p = buf;
+	size_t off = 0;
+
+	while (off < len) {
+		int w = xenstore_ring_write(xs_intf, p + off, len - off, true);
+
+		if (w < 0) {
+			return w;
+		}
+		if (w == 0) {
+			notify_evtchn(xs_evtchn);
+			if (k_sem_take(&xs_event_sem, XS_REPLY_TIMEOUT) != 0) {
+				return -ETIMEDOUT;
+			}
+			continue;
+		}
+		off += w;
+	}
+	notify_evtchn(xs_evtchn);
+	return (int)len;
+}
+
+/* Read @len bytes from the response ring, waiting via the event channel. */
+static int xs_read_all(void *buf, size_t len)
+{
+	uint8_t *p = buf;
+	size_t off = 0;
+
+	while (off < len) {
+		int r = xenstore_ring_read(xs_intf, p ? p + off : NULL,
+					   len - off, true);
+
+		if (r < 0) {
+			return r;
+		}
+		if (r == 0) {
+			if (k_sem_take(&xs_event_sem, XS_REPLY_TIMEOUT) != 0) {
+				return -ETIMEDOUT;
+			}
+			continue;
+		}
+		off += r;
+		/* We freed ring space; let the server know. */
+		notify_evtchn(xs_evtchn);
+	}
+	return (int)len;
+}
+
+/* One synchronous request/response exchange. */
+static int xs_talk(uint32_t type, const void *payload, size_t payload_len,
+		   char *out, size_t out_len)
+{
+	struct xsd_sockmsg hdr;
+	char tmp[XENSTORE_PAYLOAD_MAX];
+	size_t plen;
+	int rc;
+
+	if (!xs_connected) {
+		return -ENOTCONN;
+	}
+
+	k_mutex_lock(&xs_lock, K_FOREVER);
+
+	hdr.type = type;
+	hdr.req_id = ++xs_req_id;
+	hdr.tx_id = 0;
+	hdr.len = (uint32_t)payload_len;
+
+	rc = xs_write_all(&hdr, sizeof(hdr));
+	if (rc < 0) {
+		goto out_unlock;
+	}
+	if (payload_len) {
+		rc = xs_write_all(payload, payload_len);
+		if (rc < 0) {
+			goto out_unlock;
+		}
+	}
+
+	rc = xs_read_all(&hdr, sizeof(hdr));
+	if (rc < 0) {
+		goto out_unlock;
+	}
+
+	plen = hdr.len;
+	if (plen > sizeof(tmp)) {
+		plen = sizeof(tmp);
+	}
+	rc = xs_read_all(tmp, plen);
+	if (rc < 0) {
+		goto out_unlock;
+	}
+
+	if (hdr.type == XS_ERROR) {
+		int e = xenstore_get_error(tmp, plen);
+
+		rc = e ? -e : -EIO;
+		goto out_unlock;
+	}
+
+	if (out && out_len) {
+		size_t n = plen < out_len ? plen : out_len - 1;
+
+		memcpy(out, tmp, n);
+		out[n] = '\0';
+	}
+	rc = (int)plen;
+
+out_unlock:
+	k_mutex_unlock(&xs_lock);
+	return rc;
+}
+
+int xs_client_write(const char *path, const char *value)
+{
+	char buf[XENSTORE_ABS_PATH_MAX + XENSTORE_PAYLOAD_MAX];
+	size_t pl, vl;
+	int rc;
+
+	if (!path || !value) {
+		return -EINVAL;
+	}
+	pl = strlen(path) + 1;
+	vl = strlen(value);
+	if (pl + vl > sizeof(buf)) {
+		return -E2BIG;
+	}
+
+	memcpy(buf, path, pl);           /* path + NUL */
+	memcpy(buf + pl, value, vl);     /* value (no trailing NUL) */
+
+	rc = xs_talk(XS_WRITE, buf, pl + vl, NULL, 0);
+	return rc < 0 ? rc : 0;
+}
+
+int xs_client_read(const char *path, char *out, size_t out_len)
+{
+	if (!path) {
+		return -EINVAL;
+	}
+	return xs_talk(XS_READ, path, strlen(path) + 1, out, out_len);
+}
+
+#ifdef CONFIG_XEN_STORE_CLIENT_AUTO_CONNECT
+static int xs_client_auto_connect(void)
+{
+	int rc = xs_client_connect();
+
+	/* -ENODEV simply means this domain is not a xenstore client. */
+	if (rc && rc != -ENODEV) {
+		LOG_WRN("xenstore client auto-connect failed (%d)", rc);
+	}
+	return 0;
+}
+SYS_INIT(xs_client_auto_connect, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+#endif /* CONFIG_XEN_STORE_CLIENT_AUTO_CONNECT */

--- a/xenstore-client/src/xenstore_client.c
+++ b/xenstore-client/src/xenstore_client.c
@@ -7,6 +7,8 @@
  */
 
 #include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <zephyr/kernel.h>
@@ -76,6 +78,16 @@ static K_THREAD_STACK_DEFINE(xs_rx_stack, CONFIG_XEN_STORE_CLIENT_RX_STACK_SIZE)
 
 /* RX scratch buffer used before a reply is copied into a request ticket. */
 static char xs_rx_payload[XENSTORE_PAYLOAD_MAX];
+/* Protects the callback pointer and its user_data as one consistent pair. */
+static K_MUTEX_DEFINE(xs_watch_cb_lock);
+/* Signalled when the RX thread finishes running the current watch callback. */
+static K_CONDVAR_DEFINE(xs_watch_cb_idle);
+/* True while the RX thread is executing the copied application callback. */
+static bool xs_watch_cb_running;
+/* Single process-wide callback invoked by the RX thread for watch events. */
+static xs_client_watch_cb_t xs_watch_cb;
+/* Opaque application pointer passed back unchanged to xs_watch_cb. */
+static void *xs_watch_cb_data;
 
 static void xs_event_cb(void *priv)
 {
@@ -361,6 +373,57 @@ static void xs_complete_request_error(uint32_t req_id, int rc)
 }
 
 /*
+ * Decode and dispatch one asynchronous XS_WATCH_EVENT message.
+ *
+ * Watch events are not replies to a caller waiting in xs_talk(); they are
+ * server notifications that arrive on the same response ring. The payload is
+ * two NUL-terminated strings packed into one byte buffer: path first, then the
+ * caller-supplied watch token. The RX thread validates both strings stay inside
+ * @payload_len, then calls the single registered application callback.
+ */
+static void xs_handle_watch_event(const char *payload, size_t payload_len)
+{
+	size_t path_len;
+	size_t token_len;
+	const char *token;
+	xs_client_watch_cb_t cb;
+	void *cb_data;
+
+	if (payload_len == 0) {
+		return;
+	}
+
+	path_len = strnlen(payload, payload_len) + 1;
+	if (path_len >= payload_len) {
+		LOG_WRN("malformed xenstore watch event");
+		return;
+	}
+
+	token = payload + path_len;
+	token_len = strnlen(token, payload_len - path_len);
+	if (token_len == payload_len - path_len) {
+		LOG_WRN("malformed xenstore watch event token");
+		return;
+	}
+
+	k_mutex_lock(&xs_watch_cb_lock, K_FOREVER);
+	cb = xs_watch_cb;
+	cb_data = xs_watch_cb_data;
+	if (cb) {
+		xs_watch_cb_running = true;
+	}
+	k_mutex_unlock(&xs_watch_cb_lock);
+
+	if (cb) {
+		cb(payload, token, cb_data);
+		k_mutex_lock(&xs_watch_cb_lock, K_FOREVER);
+		xs_watch_cb_running = false;
+		k_condvar_signal(&xs_watch_cb_idle);
+		k_mutex_unlock(&xs_watch_cb_lock);
+	}
+}
+
+/*
  * Single reader for the XenStore response ring.
  *
  * The response ring is one shared incoming byte stream. Application callers do
@@ -398,7 +461,7 @@ static void xs_rx_thread_fn(void *p1, void *p2, void *p3)
 		}
 
 		if (hdr.type == XS_WATCH_EVENT) {
-			LOG_DBG("unexpected xenstore watch event");
+			xs_handle_watch_event(xs_rx_payload, hdr.len);
 			k_yield();
 			continue;
 		}
@@ -417,8 +480,8 @@ static void xs_rx_thread_fn(void *p1, void *p2, void *p3)
  * not read the response ring; it sleeps on its own ticket until the RX thread
  * completes it or XS_REPLY_TIMEOUT expires.
  */
-static int xs_talk(uint32_t type, uint32_t tx_id, const void *payload,
-		   size_t payload_len, char *out, size_t out_len)
+static int xs_talk(uint32_t type, const void *payload, size_t payload_len,
+		   char *out, size_t out_len)
 {
 	struct xs_pending_req *req;
 	struct xsd_sockmsg hdr;
@@ -443,7 +506,7 @@ static int xs_talk(uint32_t type, uint32_t tx_id, const void *payload,
 	req->payload_len = 0;
 
 	hdr.type = type;
-	hdr.tx_id = tx_id;
+	hdr.tx_id = 0;
 	hdr.len = (uint32_t)payload_len;
 
 	k_mutex_lock(&xs_pending_lock, K_FOREVER);
@@ -509,6 +572,56 @@ wait_done:
 	return (int)plen;
 }
 
+/*
+ * Send a request whose reply must be exactly one NUL-terminated string.
+ *
+ * xs_talk() is the raw transport helper: it copies reply bytes, but it does
+ * not know whether those bytes are a C string, a list of strings, or another
+ * XenStore payload format. This wrapper is for the simpler string-reply APIs.
+ * It reads into a full-size scratch buffer first, checks that the server reply
+ * contains a terminating '\0', then copies the complete string into @out.
+ *
+ * Returns the copied string size including the terminating '\0', or a negative
+ * errno. -ENOSPC means the server did return a valid string, but @out is too
+ * small to hold that whole string plus its terminator.
+ */
+static int xs_talk_string(uint32_t type, const void *payload, size_t payload_len,
+			  char *out, size_t out_len)
+{
+	char *reply;
+	size_t str_len;
+	int rc;
+
+	if (!out || out_len == 0) {
+		return -EINVAL;
+	}
+
+	reply = k_malloc(XENSTORE_PAYLOAD_MAX);
+	if (!reply) {
+		return -ENOMEM;
+	}
+
+	rc = xs_talk(type, payload, payload_len, reply, XENSTORE_PAYLOAD_MAX);
+	if (rc < 0) {
+		k_free(reply);
+		return rc;
+	}
+
+	str_len = strnlen(reply, (size_t)rc);
+	if (str_len == (size_t)rc) {
+		k_free(reply);
+		return -EINVAL;
+	}
+	if (str_len + 1 > out_len) {
+		k_free(reply);
+		return -ENOSPC;
+	}
+
+	memcpy(out, reply, str_len + 1);
+	k_free(reply);
+	return (int)(str_len + 1);
+}
+
 int xs_client_write(const char *path, const char *value)
 {
 	char *buf;
@@ -532,7 +645,7 @@ int xs_client_write(const char *path, const char *value)
 	memcpy(buf, path, pl);           /* path + NUL */
 	memcpy(buf + pl, value, vl);     /* value (no trailing NUL) */
 
-	rc = xs_talk(XS_WRITE, 0, buf, pl + vl, NULL, 0);
+	rc = xs_talk(XS_WRITE, buf, pl + vl, NULL, 0);
 	k_free(buf);
 	return rc < 0 ? rc : 0;
 }
@@ -548,7 +661,7 @@ int xs_client_read(const char *path, char *out, size_t out_len)
 		return -EINVAL;
 	}
 
-	rc = xs_talk(XS_READ, 0, path, strlen(path) + 1, out, out_len);
+	rc = xs_talk(XS_READ, path, strlen(path) + 1, out, out_len);
 	if (rc < 0) {
 		return rc;
 	}
@@ -559,6 +672,278 @@ int xs_client_read(const char *path, char *out, size_t out_len)
 
 	out[rc] = '\0';
 	return rc;
+}
+
+int xs_client_directory(const char *path, char *out, size_t out_len)
+{
+	int rc;
+
+	if (!path) {
+		return -EINVAL;
+	}
+	if (!out || out_len == 0) {
+		return -EINVAL;
+	}
+
+	rc = xs_talk(XS_DIRECTORY, path, strlen(path) + 1, out, out_len);
+	if (rc < 0) {
+		return rc;
+	}
+	if ((size_t)rc > out_len) {
+		return -ENOSPC;
+	}
+
+	return rc;
+}
+
+int xs_client_mkdir(const char *path)
+{
+	int rc;
+
+	if (!path) {
+		return -EINVAL;
+	}
+
+	rc = xs_talk(XS_MKDIR, path, strlen(path) + 1, NULL, 0);
+	return rc < 0 ? rc : 0;
+}
+
+int xs_client_rm(const char *path)
+{
+	int rc;
+
+	if (!path) {
+		return -EINVAL;
+	}
+
+	rc = xs_talk(XS_RM, path, strlen(path) + 1, NULL, 0);
+	return rc < 0 ? rc : 0;
+}
+
+/*
+ * Decode one XenStore permission string into the public permission struct.
+ *
+ * The server sends permissions as text entries such as "b1" or "r42": the
+ * first character is the access mode, and the decimal suffix is the domain id
+ * the mode applies to. This helper parses one such entry after the caller has
+ * split the raw XS_GET_PERMS reply into individual NUL-terminated strings.
+ */
+static int xs_parse_perm_string(const char *str, struct xenstore_perm *perm)
+{
+	char *endptr;
+	int rc;
+
+	if (!str || !perm) {
+		return -EINVAL;
+	}
+
+	rc = xenstore_perm_from_char(str[0], &perm->perms);
+	if (rc) {
+		return rc;
+	}
+
+	perm->domid = strtoul(str + 1, &endptr, 10);
+	if (*endptr != '\0') {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int xs_client_get_perms(const char *path, struct xenstore_perm *perms,
+			size_t *num_perms)
+{
+	char *payload;
+	size_t off = 0, count = 0, capacity;
+	int rc;
+
+	if (!path || !num_perms) {
+		return -EINVAL;
+	}
+
+	capacity = *num_perms;
+	payload = k_malloc(XENSTORE_PAYLOAD_MAX);
+	if (!payload) {
+		return -ENOMEM;
+	}
+
+	rc = xs_talk(XS_GET_PERMS, path, strlen(path) + 1, payload,
+		     XENSTORE_PAYLOAD_MAX);
+	if (rc < 0) {
+		k_free(payload);
+		return rc;
+	}
+
+	while (off < (size_t)rc) {
+		size_t remaining = (size_t)rc - off;
+		size_t len = strnlen(payload + off, remaining);
+
+		if (len == remaining) {
+			k_free(payload);
+			return -EINVAL;
+		}
+		if (perms && count < capacity) {
+			int parse_rc = xs_parse_perm_string(payload + off, &perms[count]);
+
+			if (parse_rc) {
+				k_free(payload);
+				return parse_rc;
+			}
+		}
+		count++;
+		off += len + 1;
+	}
+
+	if (perms && capacity < count) {
+		*num_perms = count;
+		k_free(payload);
+		return -ENOSPC;
+	}
+
+	*num_perms = count;
+	k_free(payload);
+	return 0;
+}
+
+/*
+ * Append one permission entry to an XS_SET_PERMS request payload.
+ *
+ * XenStore sends permissions as compact strings: access character followed by
+ * domain id, for example "b1". @off points to the next free byte in @buf.
+ * snprintk() writes the entry plus its terminating '\0'; on success @off moves
+ * past that terminator so the next permission string can be appended directly
+ * after it.
+ */
+static int xs_append_perm(char *buf, size_t buf_len, size_t *off,
+			  const struct xenstore_perm *perm)
+{
+	int len;
+
+	if (!buf || !off || !perm || *off >= buf_len) {
+		return -EINVAL;
+	}
+
+	len = snprintk(buf + *off, buf_len - *off, "%c%u",
+		       xenstore_perm_to_char(perm->perms), perm->domid);
+	if (len < 0 || (size_t)len >= buf_len - *off) {
+		return -E2BIG;
+	}
+
+	*off += (size_t)len + 1;
+
+	return 0;
+}
+
+int xs_client_set_perms(const char *path, const struct xenstore_perm *perms,
+			size_t num_perms)
+{
+	char *payload;
+	size_t off;
+	int rc;
+
+	if (!path || !perms || num_perms == 0) {
+		return -EINVAL;
+	}
+
+	off = strlen(path) + 1;
+	if (off >= XENSTORE_PAYLOAD_MAX) {
+		return -E2BIG;
+	}
+	payload = k_malloc(XENSTORE_PAYLOAD_MAX);
+	if (!payload) {
+		return -ENOMEM;
+	}
+	memcpy(payload, path, off);
+
+	for (size_t i = 0; i < num_perms; i++) {
+		rc = xs_append_perm(payload, XENSTORE_PAYLOAD_MAX, &off, &perms[i]);
+		if (rc) {
+			k_free(payload);
+			return rc;
+		}
+	}
+
+	rc = xs_talk(XS_SET_PERMS, payload, off, NULL, 0);
+	k_free(payload);
+	return rc < 0 ? rc : 0;
+}
+
+void xs_client_set_watch_callback(xs_client_watch_cb_t cb, void *user_data)
+{
+	k_mutex_lock(&xs_watch_cb_lock, K_FOREVER);
+	while (xs_watch_cb_running && k_current_get() != &xs_rx_thread) {
+		k_condvar_wait(&xs_watch_cb_idle, &xs_watch_cb_lock, K_FOREVER);
+	}
+	xs_watch_cb = cb;
+	xs_watch_cb_data = user_data;
+	k_mutex_unlock(&xs_watch_cb_lock);
+}
+
+/*
+ * Send XS_WATCH or XS_UNWATCH.
+ *
+ * Both requests use the same wire payload shape: the watched path followed by
+ * the caller-chosen token, packed as two adjacent NUL-terminated strings
+ * (`path\0token\0`). @type selects whether the server should add or remove
+ * that watch entry.
+ */
+static int xs_watch_op(uint32_t type, const char *path, const char *token)
+{
+	char *payload;
+	const char *strings[] = { path, token };
+	size_t payload_len;
+	int rc;
+
+	if (!path || !token) {
+		return -EINVAL;
+	}
+
+	payload = k_malloc(XENSTORE_PAYLOAD_MAX);
+	if (!payload) {
+		return -ENOMEM;
+	}
+
+	rc = xenstore_pack_strings(payload, XENSTORE_PAYLOAD_MAX, strings,
+				   ARRAY_SIZE(strings), &payload_len);
+	if (rc) {
+		k_free(payload);
+		return rc;
+	}
+
+	rc = xs_talk(type, payload, payload_len, NULL, 0);
+	k_free(payload);
+	return rc < 0 ? rc : 0;
+}
+
+int xs_client_watch(const char *path, const char *token)
+{
+	return xs_watch_op(XS_WATCH, path, token);
+}
+
+int xs_client_unwatch(const char *path, const char *token)
+{
+	return xs_watch_op(XS_UNWATCH, path, token);
+}
+
+int xs_client_reset_watches(void)
+{
+	int rc = xs_talk(XS_RESET_WATCHES, NULL, 0, NULL, 0);
+
+	return rc < 0 ? rc : 0;
+}
+
+int xs_client_get_domain_path(domid_t domid, char *out, size_t out_len)
+{
+	char payload[16];
+	int len;
+
+	len = snprintk(payload, sizeof(payload), "%u", domid);
+	if (len < 0 || (size_t)len >= sizeof(payload)) {
+		return -E2BIG;
+	}
+
+	return xs_talk_string(XS_GET_DOMAIN_PATH, payload, (size_t)len, out,
+			      out_len);
 }
 
 #ifdef CONFIG_XEN_STORE_CLIENT_AUTO_CONNECT

--- a/xenstore-client/src/xenstore_client.c
+++ b/xenstore-client/src/xenstore_client.c
@@ -30,16 +30,19 @@
 
 LOG_MODULE_REGISTER(xenstore_client);
 
-#define XS_REPLY_TIMEOUT K_MSEC(5000)
+#ifndef CONFIG_XEN_STORE_CLIENT_DEFAULT_TIMEOUT_MS
+#define CONFIG_XEN_STORE_CLIENT_DEFAULT_TIMEOUT_MS 5000
+#endif
+#define XS_DEFAULT_TIMEOUT K_MSEC(CONFIG_XEN_STORE_CLIENT_DEFAULT_TIMEOUT_MS)
 #define XS_RING_POLL_SPINS 16
 
 /*
  * One in-flight XenStore request.
  *
  * A caller thread creates this ticket before it writes a request into the
- * shared XenStore ring. The RX thread later reads replies from that same ring,
- * finds the ticket by req_id, copies the matching reply here, and wakes the
- * caller through done.
+ * shared XenStore ring. RX work later reads replies from that same ring, finds
+ * the ticket by req_id, copies the matching reply here, and wakes the caller
+ * through done.
  */
 struct xs_pending_req {
 	sys_snode_t node;          /* Link in the global pending-request list. */
@@ -48,18 +51,17 @@ struct xs_pending_req {
 	uint32_t req_id;           /* Wire id used to match a reply to this request. */
 	int rc;                    /* Local transport error, or 0 when a reply arrived. */
 	size_t payload_len;        /* Number of valid reply bytes in payload. */
-	char payload[XENSTORE_PAYLOAD_MAX]; /* Reply body copied by the RX thread. */
+	char *out;                 /* Caller buffer for successful reply bytes. */
+	size_t out_len;            /* Size of the caller buffer. */
 };
 
 static struct xenstore_domain_interface *xs_intf;
 static evtchn_port_t xs_evtchn;
-/* RX waits on this when the response ring is empty. */
-static struct k_sem xs_rx_sem;
 /* TX waits on this when the request ring is full. */
 static struct k_sem xs_tx_sem;
 /* Counts free request tickets; callers wait here when all tickets are busy. */
 static struct k_sem xs_pending_slots;
-/* Serializes connection setup so only one RX thread/ring binding is created. */
+/* Serializes connection setup so only one RX workqueue/ring binding is created. */
 static K_MUTEX_DEFINE(xs_connect_lock);
 /* Serializes bytes written by callers into the shared request ring. */
 static struct k_mutex xs_tx_lock;
@@ -71,29 +73,137 @@ static sys_slist_t xs_pending_reqs;
 static uint32_t xs_req_id;
 /* True after the XenStore page is mapped and the event channel is bound. */
 static bool xs_connected;
+/* Protects the default timeout value used by simple public APIs. */
+static K_MUTEX_DEFINE(xs_default_timeout_lock);
+/* Default blocking policy for APIs that do not take an explicit timeout. */
+static k_timeout_t xs_default_timeout = XS_DEFAULT_TIMEOUT;
 
-static void xs_rx_thread_fn(void *p1, void *p2, void *p3);
-static struct k_thread xs_rx_thread;
+static void xs_rx_work_handler(struct k_work *work);
 static K_THREAD_STACK_DEFINE(xs_rx_stack, CONFIG_XEN_STORE_CLIENT_RX_STACK_SIZE);
+static struct k_work_q xs_rx_workq;
+static struct k_work xs_rx_work;
+static bool xs_rx_workq_started;
 
 /* RX scratch buffer used before a reply is copied into a request ticket. */
 static char xs_rx_payload[XENSTORE_PAYLOAD_MAX];
+static struct xsd_sockmsg xs_rx_hdr;
+static size_t xs_rx_hdr_pos;
+static size_t xs_rx_payload_pos;
+static size_t xs_rx_discard_len;
+/* Protects routed watcher descriptors and legacy callback state. */
+static K_MUTEX_DEFINE(xs_watch_lock);
+/* Signalled when a routed watcher callback finishes. */
+static K_CONDVAR_DEFINE(xs_watch_idle);
+/* Registered application-owned watcher descriptors. */
+static sys_slist_t xs_watchers;
 /* Protects the callback pointer and its user_data as one consistent pair. */
 static K_MUTEX_DEFINE(xs_watch_cb_lock);
-/* Signalled when the RX thread finishes running the current watch callback. */
+/* Signalled when RX work finishes running the current watch callback. */
 static K_CONDVAR_DEFINE(xs_watch_cb_idle);
-/* True while the RX thread is executing the copied application callback. */
+/* True while RX work is executing the copied application callback. */
 static bool xs_watch_cb_running;
-/* Single process-wide callback invoked by the RX thread for watch events. */
+/* Single process-wide callback invoked by RX work for watch events. */
 static xs_client_watch_cb_t xs_watch_cb;
 /* Opaque application pointer passed back unchanged to xs_watch_cb. */
 static void *xs_watch_cb_data;
+
+static k_timeout_t xs_get_default_timeout_locked(void)
+{
+	k_timeout_t timeout;
+
+	k_mutex_lock(&xs_default_timeout_lock, K_FOREVER);
+	timeout = xs_default_timeout;
+	k_mutex_unlock(&xs_default_timeout_lock);
+
+	return timeout;
+}
+
+/*
+ * Allocate the next wire request id.
+ *
+ * XenStore uses req_id to connect a response back to the original request.
+ * Keep id 0 unused because watch events are asynchronous notifications, not
+ * replies to a caller-owned request ticket.
+ *
+ * The caller must hold xs_pending_lock. That lock already protects insertion
+ * into the pending-request list, so it also serializes the small request-id
+ * counter without pulling architecture-specific atomic helpers into the guest.
+ */
+static uint32_t xs_next_req_id(void)
+{
+	uint32_t req_id;
+
+	xs_req_id++;
+	req_id = xs_req_id;
+	if (req_id == 0) {
+		xs_req_id++;
+		req_id = xs_req_id;
+	}
+
+	return req_id;
+}
+
+/*
+ * Wake every caller that is still waiting for a reply.
+ *
+ * This is used for transport-wide failures. In plain terms, if the shared
+ * mailbox is known broken, callers should get the same clear error now instead
+ * of each thread waiting for its own timeout.
+ */
+static void xs_fail_all_pending(int rc)
+{
+	struct xs_pending_req *req;
+	struct xs_pending_req *next;
+
+	k_mutex_lock(&xs_pending_lock, K_FOREVER);
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&xs_pending_reqs, req, next, node) {
+		sys_slist_find_and_remove(&xs_pending_reqs, &req->node);
+		k_sem_give(&xs_pending_slots);
+		req->rc = rc;
+		k_sem_give(&req->done);
+	}
+	k_mutex_unlock(&xs_pending_lock);
+}
+
+static void xs_mark_transport_failed(int rc)
+{
+	k_mutex_lock(&xs_connect_lock, K_FOREVER);
+	xs_connected = false;
+	k_mutex_unlock(&xs_connect_lock);
+
+	xs_fail_all_pending(rc);
+	k_sem_give(&xs_tx_sem);
+}
+
+static bool xs_in_rx_context(void)
+{
+	return xs_rx_workq_started &&
+	       k_current_get() == k_work_queue_thread_get(&xs_rx_workq);
+}
+
+static void xs_rx_submit(void)
+{
+	if (xs_rx_workq_started) {
+		(void)k_work_submit_to_queue(&xs_rx_workq, &xs_rx_work);
+	}
+}
+
+static bool xs_has_pending_requests(void)
+{
+	bool has_pending;
+
+	k_mutex_lock(&xs_pending_lock, K_FOREVER);
+	has_pending = !sys_slist_is_empty(&xs_pending_reqs);
+	k_mutex_unlock(&xs_pending_lock);
+
+	return has_pending;
+}
 
 static void xs_event_cb(void *priv)
 {
 	ARG_UNUSED(priv);
 	/* One Xen doorbell can mean either new replies or freed request space. */
-	k_sem_give(&xs_rx_sem);
+	xs_rx_submit();
 	k_sem_give(&xs_tx_sem);
 }
 
@@ -124,13 +234,30 @@ int xs_client_connect(void)
 		goto out_unlock;
 	}
 
-	k_sem_init(&xs_rx_sem, 0, 1);
 	k_sem_init(&xs_tx_sem, 0, 1);
 	k_sem_init(&xs_pending_slots, CONFIG_XEN_STORE_CLIENT_MAX_PENDING,
 		   CONFIG_XEN_STORE_CLIENT_MAX_PENDING);
 	k_mutex_init(&xs_tx_lock);
 	k_mutex_init(&xs_pending_lock);
 	sys_slist_init(&xs_pending_reqs);
+	sys_slist_init(&xs_watchers);
+	xs_req_id = 0;
+	xs_rx_hdr_pos = 0;
+	xs_rx_payload_pos = 0;
+	xs_rx_discard_len = 0;
+
+	if (!xs_rx_workq_started) {
+		const struct k_work_queue_config cfg = {
+			.name = "xenstore-client-rx",
+		};
+
+		k_work_queue_init(&xs_rx_workq);
+		k_work_init(&xs_rx_work, xs_rx_work_handler);
+		k_work_queue_start(&xs_rx_workq, xs_rx_stack,
+				   K_THREAD_STACK_SIZEOF(xs_rx_stack),
+				   CONFIG_XEN_STORE_CLIENT_RX_PRIORITY, &cfg);
+		xs_rx_workq_started = true;
+	}
 
 	/* Map the guest's own xenstore ring page. */
 	device_map(&va, (uintptr_t)(store_pfn << XEN_PAGE_SHIFT), XEN_PAGE_SIZE,
@@ -144,7 +271,14 @@ int xs_client_connect(void)
 		goto out_unlock;
 	}
 	xs_evtchn = (evtchn_port_t)store_evtchn;
-	unmask_event_channel(xs_evtchn);
+	rc = unmask_event_channel(xs_evtchn);
+	if (rc < 0) {
+		LOG_ERR("unmask store evtchn %u failed (%d)", xs_evtchn, rc);
+		unbind_event_channel(xs_evtchn);
+		(void)evtchn_close(xs_evtchn);
+		xs_evtchn = 0;
+		goto out_unlock;
+	}
 
 	/*
 	 * Reconnection handshake. Xen initialises a dom0less client's ring to
@@ -162,9 +296,7 @@ int xs_client_connect(void)
 	}
 
 	xs_connected = true;
-	k_thread_create(&xs_rx_thread, xs_rx_stack, K_THREAD_STACK_SIZEOF(xs_rx_stack),
-			xs_rx_thread_fn, NULL, NULL, NULL,
-			CONFIG_XEN_STORE_CLIENT_RX_PRIORITY, 0, K_NO_WAIT);
+	xs_rx_submit();
 	LOG_INF("xenstore client connected (gfn 0x%llx, evtchn %u)",
 		store_pfn, xs_evtchn);
 	rc = 0;
@@ -185,28 +317,47 @@ bool xs_client_is_connected(void)
 	return connected;
 }
 
+void xs_client_set_default_timeout(k_timeout_t timeout)
+{
+	k_mutex_lock(&xs_default_timeout_lock, K_FOREVER);
+	xs_default_timeout = timeout;
+	k_mutex_unlock(&xs_default_timeout_lock);
+}
+
+k_timeout_t xs_client_get_default_timeout(void)
+{
+	return xs_get_default_timeout_locked();
+}
+
 /*
  * Copy exactly len request bytes from buf into the XenStore request ring.
  *
  * The request ring is a small shared byte queue from client to server. If it
  * is full, this helper rings the server doorbell and waits on xs_tx_sem until
  * an event suggests the server may have consumed bytes. On success it returns
- * len. On ring/write/wait failure it returns a negative errno.
+ * len. @timeout controls how long to wait when the server has not freed ring
+ * space yet. On ring/write/wait failure it returns a negative errno.
  */
-static int xs_write_all(const void *buf, size_t len)
+static int xs_write_all(const void *buf, size_t len, k_timeout_t timeout)
 {
 	const uint8_t *p = buf;
 	size_t off = 0;
 
 	while (off < len) {
+		if (xenstore_check_indexes(xs_intf->req_cons, xs_intf->req_prod)) {
+			xs_mark_transport_failed(-EIO);
+			return -EIO;
+		}
+
 		int w = xenstore_ring_write(xs_intf, p + off, len - off, true);
 
 		if (w < 0) {
+			xs_mark_transport_failed(w);
 			return w;
 		}
 		if (w == 0) {
 			notify_evtchn(xs_evtchn);
-			if (k_sem_take(&xs_tx_sem, XS_REPLY_TIMEOUT) != 0) {
+			if (k_sem_take(&xs_tx_sem, timeout) != 0) {
 				return -ETIMEDOUT;
 			}
 			continue;
@@ -221,9 +372,9 @@ static int xs_write_all(const void *buf, size_t len)
  * Copy up to len currently available response bytes from the XenStore ring.
  *
  * This helper is intentionally non-blocking for "no bytes available". The RX
- * thread is the only response-ring reader, and xs_read_full() owns the waiting
- * policy. A positive return can therefore be a short read, zero means the ring
- * had no more bytes right now, and a negative value is a ring read error.
+ * work item is the only response-ring reader. A positive return can therefore
+ * be a short read, zero means the ring had no more bytes right now, and a
+ * negative value is a ring read error.
  */
 static int xs_read_all(void *buf, size_t len)
 {
@@ -231,10 +382,16 @@ static int xs_read_all(void *buf, size_t len)
 	size_t off = 0;
 
 	while (off < len) {
+		if (xenstore_check_indexes(xs_intf->rsp_cons, xs_intf->rsp_prod)) {
+			xs_mark_transport_failed(-EIO);
+			return -EIO;
+		}
+
 		int r = xenstore_ring_read(xs_intf, p ? p + off : NULL,
 					   len - off, true);
 
 		if (r < 0) {
+			xs_mark_transport_failed(r);
 			return r;
 		}
 		if (r == 0) {
@@ -246,52 +403,41 @@ static int xs_read_all(void *buf, size_t len)
 	return (int)len;
 }
 
-/*
- * Wait until exactly len response bytes have been consumed.
- *
- * The RX thread uses this when it needs a complete XenStore header or payload
- * before dispatching a message. If buf is NULL, bytes are discarded; this is
- * used to drain an oversized payload so the next message starts at a clean
- * ring position. On success it returns len, otherwise a negative errno.
- */
-static int xs_read_full(void *buf, size_t len)
+static int xs_rsp_avail(size_t *avail)
 {
-	uint8_t *p = buf;
-	size_t off = 0;
+	XENSTORE_RING_IDX cons = xs_intf->rsp_cons;
+	XENSTORE_RING_IDX prod = xs_intf->rsp_prod;
 
-	while (off < len) {
-		int r = xs_read_all(p ? p + off : NULL, len - off);
-
-		if (r < 0) {
-			return r;
-		}
-		if (r == 0) {
-			notify_evtchn(xs_evtchn);
-			for (int i = 0; i < XS_RING_POLL_SPINS; i++) {
-				k_busy_wait(50);
-				r = xs_read_all(p ? p + off : NULL, len - off);
-				if (r != 0) {
-					break;
-				}
-			}
-			if (r == 0) {
-				k_yield();
-				continue;
-			}
-			if (r < 0) {
-				return r;
-			}
-		}
-		off += r;
+	z_barrier_dmem_fence_full();
+	if (xenstore_check_indexes(cons, prod)) {
+		xs_mark_transport_failed(-EIO);
+		*avail = 0;
+		return -EIO;
 	}
-	return (int)len;
+
+	*avail = prod - cons;
+	return 0;
+}
+
+static void xs_rx_frame_reset(void)
+{
+	xs_rx_hdr_pos = 0;
+	xs_rx_payload_pos = 0;
+	xs_rx_discard_len = 0;
+}
+
+static void xs_rx_frame_discard(size_t len)
+{
+	xs_rx_hdr_pos = 0;
+	xs_rx_payload_pos = 0;
+	xs_rx_discard_len = len;
 }
 
 /*
  * Find the pending ticket for one wire request id.
  *
  * The caller must already hold xs_pending_lock because the pending list is
- * shared by caller threads and the RX thread. When prev is not NULL, it is
+ * shared by caller threads and RX work. When prev is not NULL, it is
  * filled with the previous list node so sys_slist_remove() can unlink the
  * found ticket from Zephyr's singly linked list.
  */
@@ -317,7 +463,7 @@ static struct xs_pending_req *xs_find_pending_locked(uint32_t req_id,
 /*
  * Finish one normal server reply and wake the waiting caller.
  *
- * The RX thread calls this after it has read a full XenStore reply. The reply
+ * RX work calls this after it has read a full XenStore reply. The reply
  * still lives in the RX scratch buffer, so this helper finds the caller's
  * pending ticket by req_id, copies the reply into that ticket, returns the
  * pending slot, and gives req->done so the caller can continue.
@@ -341,8 +487,19 @@ static void xs_complete_request(struct xsd_sockmsg *hdr, const char *payload,
 	k_sem_give(&xs_pending_slots);
 	req->hdr = *hdr;
 	req->payload_len = payload_len;
-	memcpy(req->payload, payload, payload_len);
-	req->rc = 0;
+	if (hdr->type == XS_ERROR) {
+		int err = xenstore_get_error(payload, payload_len);
+
+		req->rc = err ? -err : -EIO;
+	} else {
+		if (req->out && req->out_len) {
+			size_t n = payload_len < req->out_len ?
+				payload_len : req->out_len;
+
+			memcpy(req->out, payload, n);
+		}
+		req->rc = 0;
+	}
 	k_sem_give(&req->done);
 	k_mutex_unlock(&xs_pending_lock);
 }
@@ -372,13 +529,37 @@ static void xs_complete_request_error(uint32_t req_id, int rc)
 	k_mutex_unlock(&xs_pending_lock);
 }
 
+static bool xs_watch_path_matches(const char *watch_path, const char *event_path)
+{
+	size_t watch_len;
+
+	if (!watch_path || !event_path) {
+		return false;
+	}
+
+	watch_len = strlen(watch_path);
+	if (strncmp(event_path, watch_path, watch_len) != 0) {
+		return false;
+	}
+
+	return event_path[watch_len] == '\0' || event_path[watch_len] == '/';
+}
+
+static bool xs_watcher_matches(struct xs_client_watcher *watcher,
+			       const char *path, const char *token)
+{
+	return watcher->active && watcher->cb &&
+	       strcmp(watcher->token, token) == 0 &&
+	       xs_watch_path_matches(watcher->path, path);
+}
+
 /*
  * Decode and dispatch one asynchronous XS_WATCH_EVENT message.
  *
  * Watch events are not replies to a caller waiting in xs_talk(); they are
  * server notifications that arrive on the same response ring. The payload is
  * two NUL-terminated strings packed into one byte buffer: path first, then the
- * caller-supplied watch token. The RX thread validates both strings stay inside
+ * caller-supplied watch token. RX work validates both strings stay inside
  * @payload_len, then calls the single registered application callback.
  */
 static void xs_handle_watch_event(const char *payload, size_t payload_len)
@@ -388,6 +569,7 @@ static void xs_handle_watch_event(const char *payload, size_t payload_len)
 	const char *token;
 	xs_client_watch_cb_t cb;
 	void *cb_data;
+	struct xs_client_watcher *watcher;
 
 	if (payload_len == 0) {
 		return;
@@ -421,6 +603,29 @@ static void xs_handle_watch_event(const char *payload, size_t payload_len)
 		k_condvar_signal(&xs_watch_cb_idle);
 		k_mutex_unlock(&xs_watch_cb_lock);
 	}
+
+	k_mutex_lock(&xs_watch_lock, K_FOREVER);
+	SYS_SLIST_FOR_EACH_CONTAINER(&xs_watchers, watcher, node) {
+		xs_client_watch_cb_t watcher_cb;
+		void *watcher_data;
+
+		if (!xs_watcher_matches(watcher, payload, token)) {
+			continue;
+		}
+
+		watcher_cb = watcher->cb;
+		watcher_data = watcher->user_data;
+		watcher->running = true;
+		k_mutex_unlock(&xs_watch_lock);
+
+		watcher_cb(payload, token, watcher_data);
+
+		k_mutex_lock(&xs_watch_lock, K_FOREVER);
+		watcher->running = false;
+		k_condvar_signal(&xs_watch_idle);
+		break;
+	}
+	k_mutex_unlock(&xs_watch_lock);
 }
 
 /*
@@ -428,46 +633,135 @@ static void xs_handle_watch_event(const char *payload, size_t payload_len)
  *
  * The response ring is one shared incoming byte stream. Application callers do
  * not read it directly; otherwise one caller could consume another caller's
- * reply. This thread reads each message, handles watch events immediately, and
- * routes normal replies to the matching pending request by req_id.
+ * reply. The work item runs when the event channel fires, reads only bytes
+ * already visible in the ring, keeps partial header/payload state between
+ * runs, handles watch events, and routes normal replies by req_id.
  */
-static void xs_rx_thread_fn(void *p1, void *p2, void *p3)
+static int xs_rx_process_one(size_t avail)
 {
-	struct xsd_sockmsg hdr;
+	int rc;
 
-	ARG_UNUSED(p1);
-	ARG_UNUSED(p2);
-	ARG_UNUSED(p3);
+	if (xs_rx_hdr_pos < sizeof(xs_rx_hdr)) {
+		size_t need = sizeof(xs_rx_hdr) - xs_rx_hdr_pos;
+		size_t take = MIN(need, avail);
 
-	while (true) {
+		rc = xs_read_all((uint8_t *)&xs_rx_hdr + xs_rx_hdr_pos, take);
+		if (rc < 0) {
+			return rc;
+		}
+		if (rc == 0) {
+			return -EAGAIN;
+		}
+
+		xs_rx_hdr_pos += (size_t)rc;
+		avail -= (size_t)rc;
+		if (xs_rx_hdr_pos < sizeof(xs_rx_hdr)) {
+			return -EAGAIN;
+		}
+	}
+
+	if (xs_rx_hdr.len > sizeof(xs_rx_payload)) {
+		LOG_ERR("xenstore response payload too large (%u)", xs_rx_hdr.len);
+		if (xs_rx_hdr.type != XS_WATCH_EVENT) {
+			xs_complete_request_error(xs_rx_hdr.req_id, -E2BIG);
+		}
+		xs_rx_frame_discard(xs_rx_hdr.len);
+		return -EMSGSIZE;
+	}
+
+	if (xs_rx_hdr.type != XS_WATCH_EVENT && xs_rx_hdr.req_id == 0) {
+		LOG_ERR("xenstore reply without request id");
+		xs_rx_frame_discard(xs_rx_hdr.len);
+		return -EPROTO;
+	}
+
+	if (xs_rx_hdr.len > xs_rx_payload_pos) {
+		size_t need = xs_rx_hdr.len - xs_rx_payload_pos;
+		size_t take = MIN(need, avail);
+
+		rc = xs_read_all(xs_rx_payload + xs_rx_payload_pos, take);
+		if (rc < 0) {
+			if (xs_rx_hdr.type != XS_WATCH_EVENT) {
+				xs_complete_request_error(xs_rx_hdr.req_id, rc);
+			}
+			return rc;
+		}
+		if (rc == 0) {
+			return -EAGAIN;
+		}
+
+		xs_rx_payload_pos += (size_t)rc;
+		if (xs_rx_payload_pos < xs_rx_hdr.len) {
+			return -EAGAIN;
+		}
+	}
+
+	if (xs_rx_hdr.type == XS_WATCH_EVENT) {
+		xs_handle_watch_event(xs_rx_payload, xs_rx_hdr.len);
+	} else {
+		xs_complete_request(&xs_rx_hdr, xs_rx_payload, xs_rx_hdr.len);
+	}
+	xs_rx_frame_reset();
+
+	return 0;
+}
+
+static void xs_rx_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	while (xs_connected) {
+		size_t avail;
+		size_t take;
 		int rc;
 
-		rc = xs_read_full(&hdr, sizeof(hdr));
-		if (rc < 0) {
-			LOG_ERR("xenstore response header read failed (%d)", rc);
+		rc = xs_rsp_avail(&avail);
+		if (rc < 0 || avail == 0) {
+			if (rc == 0 && xs_has_pending_requests()) {
+				for (int i = 0; i < XS_RING_POLL_SPINS; i++) {
+					k_busy_wait(50);
+					rc = xs_rsp_avail(&avail);
+					if (rc < 0 || avail > 0) {
+						break;
+					}
+				}
+				if (rc == 0 && avail == 0) {
+					k_yield();
+				}
+				if (rc == 0 && avail > 0) {
+					continue;
+				}
+				if (rc == 0 && xs_has_pending_requests()) {
+					xs_rx_submit();
+				}
+			}
+			return;
+		}
+
+		if (xs_rx_discard_len > 0) {
+			take = MIN(xs_rx_discard_len, avail);
+			rc = xs_read_all(NULL, take);
+			if (rc < 0) {
+				return;
+			}
+			if (rc == 0) {
+				return;
+			}
+			xs_rx_discard_len -= (size_t)rc;
+			if (xs_rx_discard_len > 0) {
+				return;
+			}
 			continue;
 		}
 
-		if (hdr.len > sizeof(xs_rx_payload)) {
-			(void)xs_read_full(NULL, hdr.len);
-			xs_complete_request_error(hdr.req_id, -E2BIG);
-			continue;
+		rc = xs_rx_process_one(avail);
+		if (rc == -EAGAIN) {
+			return;
 		}
-
-		rc = xs_read_full(xs_rx_payload, hdr.len);
-		if (rc < 0) {
-			xs_complete_request_error(hdr.req_id, rc);
-			continue;
+		if (rc < 0 && xs_rx_discard_len == 0) {
+			xs_mark_transport_failed(rc);
+			return;
 		}
-
-		if (hdr.type == XS_WATCH_EVENT) {
-			xs_handle_watch_event(xs_rx_payload, hdr.len);
-			k_yield();
-			continue;
-		}
-
-		xs_complete_request(&hdr, xs_rx_payload, hdr.len);
-		k_yield();
 	}
 }
 
@@ -477,18 +771,18 @@ static void xs_rx_thread_fn(void *p1, void *p2, void *p3)
  * The caller takes a pending slot, creates a request ticket, registers it by a
  * fresh req_id, and writes the request header/payload under xs_tx_lock so bytes
  * from concurrent callers cannot interleave. After the write, the caller does
- * not read the response ring; it sleeps on its own ticket until the RX thread
- * completes it or XS_REPLY_TIMEOUT expires.
+ * not read the response ring; it sleeps on its own ticket until RX work
+ * completes it or @timeout expires.
  */
 static int xs_talk(uint32_t type, const void *payload, size_t payload_len,
-		   char *out, size_t out_len)
+		   char *out, size_t out_len, k_timeout_t timeout)
 {
-	struct xs_pending_req *req;
+	struct xs_pending_req req;
 	struct xsd_sockmsg hdr;
 	size_t plen;
 	int rc;
 
-	if (!xs_connected) {
+	if (!xs_client_is_connected()) {
 		return -ENOTCONN;
 	}
 	if (payload_len > XENSTORE_PAYLOAD_MAX) {
@@ -496,79 +790,61 @@ static int xs_talk(uint32_t type, const void *payload, size_t payload_len,
 	}
 
 	k_sem_take(&xs_pending_slots, K_FOREVER);
-	req = k_malloc(sizeof(*req));
-	if (!req) {
-		k_sem_give(&xs_pending_slots);
-		return -ENOMEM;
-	}
-	k_sem_init(&req->done, 0, 1);
-	req->rc = -EIO;
-	req->payload_len = 0;
+	req.node.next = NULL;
+	k_sem_init(&req.done, 0, 1);
+	req.rc = -EIO;
+	req.payload_len = 0;
+	req.out = out;
+	req.out_len = out_len;
 
 	hdr.type = type;
 	hdr.tx_id = 0;
 	hdr.len = (uint32_t)payload_len;
 
 	k_mutex_lock(&xs_pending_lock, K_FOREVER);
-	hdr.req_id = ++xs_req_id;
-	req->req_id = hdr.req_id;
-	sys_slist_append(&xs_pending_reqs, &req->node);
+	hdr.req_id = xs_next_req_id();
+	req.req_id = hdr.req_id;
+	sys_slist_append(&xs_pending_reqs, &req.node);
 	k_mutex_unlock(&xs_pending_lock);
 
 	k_mutex_lock(&xs_tx_lock, K_FOREVER);
-	rc = xs_write_all(&hdr, sizeof(hdr));
+	rc = xs_write_all(&hdr, sizeof(hdr), timeout);
 	if (rc < 0) {
 		k_mutex_unlock(&xs_tx_lock);
-		xs_complete_request_error(req->req_id, rc);
+		xs_complete_request_error(req.req_id, rc);
 		goto wait_done;
 	}
 	if (payload_len) {
-		rc = xs_write_all(payload, payload_len);
+		rc = xs_write_all(payload, payload_len, timeout);
 		if (rc < 0) {
 			k_mutex_unlock(&xs_tx_lock);
-			xs_complete_request_error(req->req_id, rc);
+			xs_complete_request_error(req.req_id, rc);
 			goto wait_done;
 		}
 	}
 	notify_evtchn(xs_evtchn);
+	xs_rx_submit();
 	k_mutex_unlock(&xs_tx_lock);
 
 wait_done:
-	if (k_sem_take(&req->done, XS_REPLY_TIMEOUT) != 0) {
+	if (k_sem_take(&req.done, timeout) != 0) {
 		sys_snode_t *prev = NULL;
 
 		k_mutex_lock(&xs_pending_lock, K_FOREVER);
-		if (xs_find_pending_locked(req->req_id, &prev)) {
-			sys_slist_remove(&xs_pending_reqs, prev, &req->node);
+		if (xs_find_pending_locked(req.req_id, &prev)) {
+			sys_slist_remove(&xs_pending_reqs, prev, &req.node);
 			k_sem_give(&xs_pending_slots);
 		}
 		k_mutex_unlock(&xs_pending_lock);
-		k_free(req);
 		return -ETIMEDOUT;
 	}
 
-	if (req->rc < 0) {
-		rc = req->rc;
-		k_free(req);
+	if (req.rc < 0) {
+		rc = req.rc;
 		return rc;
 	}
 
-	plen = req->payload_len;
-	if (req->hdr.type == XS_ERROR) {
-		int e = xenstore_get_error(req->payload, plen);
-
-		rc = e ? -e : -EIO;
-		k_free(req);
-		return rc;
-	}
-
-	if (out && out_len) {
-		size_t n = plen < out_len ? plen : out_len;
-
-		memcpy(out, req->payload, n);
-	}
-
-	k_free(req);
+	plen = req.payload_len;
 	return (int)plen;
 }
 
@@ -586,7 +862,7 @@ wait_done:
  * small to hold that whole string plus its terminator.
  */
 static int xs_talk_string(uint32_t type, const void *payload, size_t payload_len,
-			  char *out, size_t out_len)
+			  char *out, size_t out_len, k_timeout_t timeout)
 {
 	char *reply;
 	size_t str_len;
@@ -601,7 +877,8 @@ static int xs_talk_string(uint32_t type, const void *payload, size_t payload_len
 		return -ENOMEM;
 	}
 
-	rc = xs_talk(type, payload, payload_len, reply, XENSTORE_PAYLOAD_MAX);
+	rc = xs_talk(type, payload, payload_len, reply, XENSTORE_PAYLOAD_MAX,
+		     timeout);
 	if (rc < 0) {
 		k_free(reply);
 		return rc;
@@ -624,6 +901,12 @@ static int xs_talk_string(uint32_t type, const void *payload, size_t payload_len
 
 int xs_client_write(const char *path, const char *value)
 {
+	return xs_client_write_timeout(path, value, xs_client_get_default_timeout());
+}
+
+int xs_client_write_timeout(const char *path, const char *value,
+			    k_timeout_t timeout)
+{
 	char *buf;
 	size_t pl, vl;
 	int rc;
@@ -645,12 +928,19 @@ int xs_client_write(const char *path, const char *value)
 	memcpy(buf, path, pl);           /* path + NUL */
 	memcpy(buf + pl, value, vl);     /* value (no trailing NUL) */
 
-	rc = xs_talk(XS_WRITE, buf, pl + vl, NULL, 0);
+	rc = xs_talk(XS_WRITE, buf, pl + vl, NULL, 0, timeout);
 	k_free(buf);
 	return rc < 0 ? rc : 0;
 }
 
 int xs_client_read(const char *path, char *out, size_t out_len)
+{
+	return xs_client_read_timeout(path, out, out_len,
+				      xs_client_get_default_timeout());
+}
+
+int xs_client_read_timeout(const char *path, char *out, size_t out_len,
+			   k_timeout_t timeout)
 {
 	int rc;
 
@@ -661,7 +951,7 @@ int xs_client_read(const char *path, char *out, size_t out_len)
 		return -EINVAL;
 	}
 
-	rc = xs_talk(XS_READ, path, strlen(path) + 1, out, out_len);
+	rc = xs_talk(XS_READ, path, strlen(path) + 1, out, out_len, timeout);
 	if (rc < 0) {
 		return rc;
 	}
@@ -676,6 +966,13 @@ int xs_client_read(const char *path, char *out, size_t out_len)
 
 int xs_client_directory(const char *path, char *out, size_t out_len)
 {
+	return xs_client_directory_timeout(path, out, out_len,
+					   xs_client_get_default_timeout());
+}
+
+int xs_client_directory_timeout(const char *path, char *out, size_t out_len,
+				k_timeout_t timeout)
+{
 	int rc;
 
 	if (!path) {
@@ -685,7 +982,8 @@ int xs_client_directory(const char *path, char *out, size_t out_len)
 		return -EINVAL;
 	}
 
-	rc = xs_talk(XS_DIRECTORY, path, strlen(path) + 1, out, out_len);
+	rc = xs_talk(XS_DIRECTORY, path, strlen(path) + 1, out, out_len,
+		     timeout);
 	if (rc < 0) {
 		return rc;
 	}
@@ -698,17 +996,10 @@ int xs_client_directory(const char *path, char *out, size_t out_len)
 
 int xs_client_mkdir(const char *path)
 {
-	int rc;
-
-	if (!path) {
-		return -EINVAL;
-	}
-
-	rc = xs_talk(XS_MKDIR, path, strlen(path) + 1, NULL, 0);
-	return rc < 0 ? rc : 0;
+	return xs_client_mkdir_timeout(path, xs_client_get_default_timeout());
 }
 
-int xs_client_rm(const char *path)
+int xs_client_mkdir_timeout(const char *path, k_timeout_t timeout)
 {
 	int rc;
 
@@ -716,7 +1007,24 @@ int xs_client_rm(const char *path)
 		return -EINVAL;
 	}
 
-	rc = xs_talk(XS_RM, path, strlen(path) + 1, NULL, 0);
+	rc = xs_talk(XS_MKDIR, path, strlen(path) + 1, NULL, 0, timeout);
+	return rc < 0 ? rc : 0;
+}
+
+int xs_client_rm(const char *path)
+{
+	return xs_client_rm_timeout(path, xs_client_get_default_timeout());
+}
+
+int xs_client_rm_timeout(const char *path, k_timeout_t timeout)
+{
+	int rc;
+
+	if (!path) {
+		return -EINVAL;
+	}
+
+	rc = xs_talk(XS_RM, path, strlen(path) + 1, NULL, 0, timeout);
 	return rc < 0 ? rc : 0;
 }
 
@@ -753,6 +1061,13 @@ static int xs_parse_perm_string(const char *str, struct xenstore_perm *perm)
 int xs_client_get_perms(const char *path, struct xenstore_perm *perms,
 			size_t *num_perms)
 {
+	return xs_client_get_perms_timeout(path, perms, num_perms,
+					   xs_client_get_default_timeout());
+}
+
+int xs_client_get_perms_timeout(const char *path, struct xenstore_perm *perms,
+				size_t *num_perms, k_timeout_t timeout)
+{
 	char *payload;
 	size_t off = 0, count = 0, capacity;
 	int rc;
@@ -768,7 +1083,7 @@ int xs_client_get_perms(const char *path, struct xenstore_perm *perms,
 	}
 
 	rc = xs_talk(XS_GET_PERMS, path, strlen(path) + 1, payload,
-		     XENSTORE_PAYLOAD_MAX);
+		     XENSTORE_PAYLOAD_MAX, timeout);
 	if (rc < 0) {
 		k_free(payload);
 		return rc;
@@ -837,6 +1152,14 @@ static int xs_append_perm(char *buf, size_t buf_len, size_t *off,
 int xs_client_set_perms(const char *path, const struct xenstore_perm *perms,
 			size_t num_perms)
 {
+	return xs_client_set_perms_timeout(path, perms, num_perms,
+					   xs_client_get_default_timeout());
+}
+
+int xs_client_set_perms_timeout(const char *path,
+				const struct xenstore_perm *perms,
+				size_t num_perms, k_timeout_t timeout)
+{
 	char *payload;
 	size_t off;
 	int rc;
@@ -863,7 +1186,7 @@ int xs_client_set_perms(const char *path, const struct xenstore_perm *perms,
 		}
 	}
 
-	rc = xs_talk(XS_SET_PERMS, payload, off, NULL, 0);
+	rc = xs_talk(XS_SET_PERMS, payload, off, NULL, 0, timeout);
 	k_free(payload);
 	return rc < 0 ? rc : 0;
 }
@@ -871,12 +1194,83 @@ int xs_client_set_perms(const char *path, const struct xenstore_perm *perms,
 void xs_client_set_watch_callback(xs_client_watch_cb_t cb, void *user_data)
 {
 	k_mutex_lock(&xs_watch_cb_lock, K_FOREVER);
-	while (xs_watch_cb_running && k_current_get() != &xs_rx_thread) {
+	while (xs_watch_cb_running && !xs_in_rx_context()) {
 		k_condvar_wait(&xs_watch_cb_idle, &xs_watch_cb_lock, K_FOREVER);
 	}
 	xs_watch_cb = cb;
 	xs_watch_cb_data = user_data;
 	k_mutex_unlock(&xs_watch_cb_lock);
+}
+
+int xs_client_watcher_register(struct xs_client_watcher *watcher,
+			       const char *path, const char *token,
+			       xs_client_watch_cb_t cb, void *user_data)
+{
+	int rc;
+
+	if (!watcher || !path || !token || !cb) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&xs_watch_lock, K_FOREVER);
+	if (watcher->active || watcher->running) {
+		k_mutex_unlock(&xs_watch_lock);
+		return -EALREADY;
+	}
+
+	watcher->path = path;
+	watcher->token = token;
+	watcher->cb = cb;
+	watcher->user_data = user_data;
+	watcher->active = true;
+	watcher->running = false;
+	sys_slist_append(&xs_watchers, &watcher->node);
+	k_mutex_unlock(&xs_watch_lock);
+
+	rc = xs_client_watch(path, token);
+	if (rc) {
+		k_mutex_lock(&xs_watch_lock, K_FOREVER);
+		if (watcher->active) {
+			(void)sys_slist_find_and_remove(&xs_watchers, &watcher->node);
+			watcher->active = false;
+		}
+		k_mutex_unlock(&xs_watch_lock);
+	}
+
+	return rc;
+}
+
+int xs_client_watcher_unregister(struct xs_client_watcher *watcher)
+{
+	const char *path;
+	const char *token;
+	bool from_rx = xs_in_rx_context();
+
+	if (!watcher) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&xs_watch_lock, K_FOREVER);
+	if (!watcher->active) {
+		k_mutex_unlock(&xs_watch_lock);
+		return -ENOENT;
+	}
+	if (from_rx && watcher->running) {
+		k_mutex_unlock(&xs_watch_lock);
+		return -EWOULDBLOCK;
+	}
+
+	while (watcher->running) {
+		k_condvar_wait(&xs_watch_idle, &xs_watch_lock, K_FOREVER);
+	}
+
+	path = watcher->path;
+	token = watcher->token;
+	(void)sys_slist_find_and_remove(&xs_watchers, &watcher->node);
+	watcher->active = false;
+	k_mutex_unlock(&xs_watch_lock);
+
+	return xs_client_unwatch(path, token);
 }
 
 /*
@@ -887,7 +1281,8 @@ void xs_client_set_watch_callback(xs_client_watch_cb_t cb, void *user_data)
  * (`path\0token\0`). @type selects whether the server should add or remove
  * that watch entry.
  */
-static int xs_watch_op(uint32_t type, const char *path, const char *token)
+static int xs_watch_op(uint32_t type, const char *path, const char *token,
+		       k_timeout_t timeout)
 {
 	char *payload;
 	const char *strings[] = { path, token };
@@ -910,29 +1305,55 @@ static int xs_watch_op(uint32_t type, const char *path, const char *token)
 		return rc;
 	}
 
-	rc = xs_talk(type, payload, payload_len, NULL, 0);
+	rc = xs_talk(type, payload, payload_len, NULL, 0, timeout);
 	k_free(payload);
 	return rc < 0 ? rc : 0;
 }
 
 int xs_client_watch(const char *path, const char *token)
 {
-	return xs_watch_op(XS_WATCH, path, token);
+	return xs_client_watch_timeout(path, token,
+				       xs_client_get_default_timeout());
+}
+
+int xs_client_watch_timeout(const char *path, const char *token,
+			    k_timeout_t timeout)
+{
+	return xs_watch_op(XS_WATCH, path, token, timeout);
 }
 
 int xs_client_unwatch(const char *path, const char *token)
 {
-	return xs_watch_op(XS_UNWATCH, path, token);
+	return xs_client_unwatch_timeout(path, token,
+					 xs_client_get_default_timeout());
+}
+
+int xs_client_unwatch_timeout(const char *path, const char *token,
+			      k_timeout_t timeout)
+{
+	return xs_watch_op(XS_UNWATCH, path, token, timeout);
 }
 
 int xs_client_reset_watches(void)
 {
-	int rc = xs_talk(XS_RESET_WATCHES, NULL, 0, NULL, 0);
+	return xs_client_reset_watches_timeout(xs_client_get_default_timeout());
+}
+
+int xs_client_reset_watches_timeout(k_timeout_t timeout)
+{
+	int rc = xs_talk(XS_RESET_WATCHES, NULL, 0, NULL, 0, timeout);
 
 	return rc < 0 ? rc : 0;
 }
 
 int xs_client_get_domain_path(domid_t domid, char *out, size_t out_len)
+{
+	return xs_client_get_domain_path_timeout(domid, out, out_len,
+						 xs_client_get_default_timeout());
+}
+
+int xs_client_get_domain_path_timeout(domid_t domid, char *out, size_t out_len,
+				      k_timeout_t timeout)
 {
 	char payload[16];
 	int len;
@@ -943,7 +1364,7 @@ int xs_client_get_domain_path(domid_t domid, char *out, size_t out_len)
 	}
 
 	return xs_talk_string(XS_GET_DOMAIN_PATH, payload, (size_t)len, out,
-			      out_len);
+			      out_len, timeout);
 }
 
 #ifdef CONFIG_XEN_STORE_CLIENT_AUTO_CONNECT

--- a/xenstore-common/include/xenstore_common.h
+++ b/xenstore-common/include/xenstore_common.h
@@ -14,10 +14,33 @@
 #include <string.h>
 #include <stdio.h>
 #include <xen/public/io/xs_wire.h>
+#include <xen/public/xen.h>
 
 #include <zephyr/sys/barrier.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/xen/events.h>
+
+/**
+ * @brief XenStore entry access permissions.
+ */
+enum xs_perm {
+	/** XenStore entry owner permissions. */
+	XS_PERM_NONE = 0x0,
+	/** XenStore entry read permissions for a guest domain. */
+	XS_PERM_READ = 0x1,
+	/** XenStore entry write permissions for a guest domain. */
+	XS_PERM_WRITE = 0x2,
+	/** XenStore entry read/write permissions for a guest domain. */
+	XS_PERM_BOTH = XS_PERM_WRITE | XS_PERM_READ
+};
+
+/**
+ * @brief XenStore wire permission entry.
+ */
+struct xenstore_perm {
+	enum xs_perm perms;
+	domid_t domid;
+};
 
 /**
  * @brief Check whether a given path is absolute.
@@ -139,7 +162,8 @@ int xenstore_ring_write(struct xenstore_domain_interface *intf, const void *data
  * @brief Read data from the XenStore ring buffer.
  *
  * @param intf   Domain interface describing the shared ring.
- * @param data   Destination buffer that receives the data.
+ * @param data   Destination buffer that receives the data, or NULL to discard
+ *               bytes while advancing the consumer index.
  * @param len    Maximum number of bytes to read.
  * @param client Set to true when invoked from a XenStore client context.
  *
@@ -147,6 +171,42 @@ int xenstore_ring_write(struct xenstore_domain_interface *intf, const void *data
  * @retval <0    Negative errno value on failure.
  */
 int xenstore_ring_read(struct xenstore_domain_interface *intf, void *data, size_t len, bool client);
+
+/**
+ * @brief Pack NUL-terminated strings into a XenStore request payload.
+ *
+ * @param buf         Destination payload buffer.
+ * @param buf_len     Size of @p buf.
+ * @param strings     Array of strings to pack.
+ * @param num_strings Number of array entries.
+ * @param payload_len Returned payload length.
+ *
+ * @retval 0        Success.
+ * @retval -EINVAL  Invalid argument or NULL string entry.
+ * @retval -E2BIG   Destination buffer is too small.
+ */
+int xenstore_pack_strings(char *buf, size_t buf_len, const char *const *strings,
+			  size_t num_strings, size_t *payload_len);
+
+/**
+ * @brief Convert a XenStore permission value to its wire character.
+ *
+ * @param perm Permission value.
+ *
+ * @return XenStore wire permission character.
+ */
+char xenstore_perm_to_char(enum xs_perm perm);
+
+/**
+ * @brief Convert a XenStore wire permission character to a permission value.
+ *
+ * @param perm_char Wire permission character.
+ * @param perm      Returned permission value.
+ *
+ * @retval 0       Success.
+ * @retval -EINVAL Unknown permission character or NULL output pointer.
+ */
+int xenstore_perm_from_char(char perm_char, enum xs_perm *perm);
 
 /**
  * @brief Convert a textual errno representation into its numeric value.

--- a/xenstore-common/src/xenstore_common.c
+++ b/xenstore-common/src/xenstore_common.c
@@ -75,8 +75,19 @@ int xenstore_get_error(const char *errstr, size_t len)
 {
 	size_t i;
 
+	if (!errstr) {
+		return 0;
+	}
+
 	for (i = 0; i < ARRAY_SIZE(xsd_errors); i++) {
-		if (strncmp(errstr, xsd_errors[i].errstring, len) == 0) {
+		const char *known = xsd_errors[i].errstring;
+		size_t known_len = strlen(known);
+
+		if (len == known_len && memcmp(errstr, known, known_len) == 0) {
+			return xsd_errors[i].errnum;
+		}
+		if (len == known_len + 1 && memcmp(errstr, known, known_len) == 0 &&
+		    errstr[known_len] == '\0') {
 			return xsd_errors[i].errnum;
 		}
 	}

--- a/xenstore-common/src/xenstore_common.c
+++ b/xenstore-common/src/xenstore_common.c
@@ -71,6 +71,76 @@ int xenstore_ring_read(struct xenstore_domain_interface *intf, void *data, size_
 	return len;
 }
 
+int xenstore_pack_strings(char *buf, size_t buf_len, const char *const *strings,
+			  size_t num_strings, size_t *payload_len)
+{
+	size_t off = 0;
+
+	if (!buf || !strings || !payload_len) {
+		return -EINVAL;
+	}
+
+	for (size_t i = 0; i < num_strings; i++) {
+		size_t str_len;
+
+		if (!strings[i]) {
+			return -EINVAL;
+		}
+
+		str_len = xenstore_str_byte_size(strings[i]);
+		if (str_len > buf_len - off) {
+			return -E2BIG;
+		}
+
+		memcpy(buf + off, strings[i], str_len);
+		off += str_len;
+	}
+
+	*payload_len = off;
+
+	return 0;
+}
+
+char xenstore_perm_to_char(enum xs_perm perm)
+{
+	switch (perm & XS_PERM_BOTH) {
+	case XS_PERM_WRITE:
+		return 'w';
+	case XS_PERM_READ:
+		return 'r';
+	case XS_PERM_BOTH:
+		return 'b';
+	default:
+		return 'n';
+	}
+}
+
+int xenstore_perm_from_char(char perm_char, enum xs_perm *perm)
+{
+	if (!perm) {
+		return -EINVAL;
+	}
+
+	switch (perm_char) {
+	case 'w':
+		*perm = XS_PERM_WRITE;
+		break;
+	case 'r':
+		*perm = XS_PERM_READ;
+		break;
+	case 'b':
+		*perm = XS_PERM_BOTH;
+		break;
+	case 'n':
+		*perm = XS_PERM_NONE;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 int xenstore_get_error(const char *errstr, size_t len)
 {
 	size_t i;

--- a/xenstore-srv/include/xss.h
+++ b/xenstore-srv/include/xss.h
@@ -10,7 +10,7 @@
 #ifndef XENLIB_XSS_H
 #define XENLIB_XSS_H
 
-#include <xen/public/xen.h>
+#include <xenstore_common.h>
 
 /**
  * @brief Xenstore access control Interface
@@ -20,20 +20,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief Xenstore entry access permissions
- */
-enum xs_perm {
-	/** Xenstore entry owner permissions */
-	XS_PERM_NONE = 0x0,
-	/** Xenstore entry read permissions for quest domain */
-	XS_PERM_READ = 0x1,
-	/** Xenstore entry write permissions for quest domain */
-	XS_PERM_WRITE = 0x2,
-	/** Xenstore entry both RW permissions for quest domain */
-	XS_PERM_BOTH = XS_PERM_WRITE | XS_PERM_READ
-};
 
 /**
  * Read the value associated with a path.

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -1375,8 +1375,14 @@ static void handle_set_perms(struct xenstore *xenstore, uint32_t id,
 	k_mutex_lock(&xsel_mutex, K_FOREVER);
 	entry = key_to_entry_check_perm(path, xenstore->domain->domid, XS_PERM_NONE);
 	k_free(path);
-	if (!entry && is_owner(entry, xenstore->domain->domid)) {
+	if (!entry) {
 		k_mutex_unlock(&xsel_mutex);
+		send_errno(xenstore, id, ENOENT);
+		return;
+	}
+	if (!is_owner(entry, xenstore->domain->domid)) {
+		k_mutex_unlock(&xsel_mutex);
+		send_errno(xenstore, id, EACCES);
 		return;
 	}
 

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -1929,7 +1929,7 @@ int start_domain_stored(struct xen_domain *domain, xen_pfn_t store_pfn)
 				       xenstore->remote_evtchn);
 		if (rc) {
 			LOG_ERR("Failed to set domain xenbus evtchn param (rc=%d)", rc);
-			goto unmap_ring;
+			goto close_evtchn;
 		}
 	}
 
@@ -1940,8 +1940,26 @@ int start_domain_stored(struct xen_domain *domain, xen_pfn_t store_pfn)
 			xenstore_evt_thrd,
 			domain, NULL, NULL, 7, 0, K_NO_WAIT);
 
+	rc = unmask_event_channel(xenstore->local_evtchn);
+	if (rc) {
+		LOG_ERR("Failed to unmask xenstore event channel (rc=%d)", rc);
+		goto stop_thread;
+	}
+
 	return 0;
 
+stop_thread:
+	atomic_set(&xenstore->thrd_stop, 1);
+	k_sem_give(&xenstore->xb_sem);
+	k_thread_join(&xenstore->thrd, K_FOREVER);
+	free_stack_idx(xenstore->xs_stack_slot);
+close_evtchn:
+	unbind_event_channel(xenstore->local_evtchn);
+	err_ret = evtchn_close(xenstore->local_evtchn);
+	if (err_ret) {
+		LOG_ERR("Unable to close event channel#%u (rc=%d)",
+			xenstore->local_evtchn, err_ret);
+	}
 unmap_ring:
 	err_ret = xenmem_unmap_region(1, xenstore->domint);
 	if (err_ret < 0) {

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -1445,10 +1445,14 @@ static int xss_do_rm(const char *key, uint32_t caller_id)
 	struct xs_entry *entry;
 
 	k_mutex_lock(&xsel_mutex, K_FOREVER);
-	entry = key_to_entry_check_perm(key, caller_id, XS_PERM_WRITE);
+	entry = key_to_entry(key);
 	if (!entry) {
 		k_mutex_unlock(&xsel_mutex);
-		return -EINVAL;
+		return -ENOENT;
+	}
+	if (!check_perms_for_entry(entry, caller_id, XS_PERM_WRITE)) {
+		k_mutex_unlock(&xsel_mutex);
+		return -EACCES;
 	}
 
 	free_node(entry);
@@ -1471,10 +1475,26 @@ int xss_rm(const char *path)
 static void handle_rm(struct xenstore *xenstore, uint32_t id, char *payload,
 	       uint32_t len)
 {
-	if (xss_do_rm(payload, xenstore->domain->domid)) {
-		notify_watchers(payload, xenstore->domain->domid);
-		send_reply_read(xenstore, id, XS_RM, "");
+	char *path;
+	int rc;
+
+	rc = construct_path(payload, xenstore->domain->domid, &path);
+	if (rc) {
+		send_errno(xenstore, id, -rc);
+		return;
 	}
+
+	rc = xss_do_rm(path, xenstore->domain->domid);
+
+	if (rc) {
+		send_errno(xenstore, id, -rc);
+		k_free(path);
+		return;
+	}
+
+	notify_watchers(path, xenstore->domain->domid);
+	k_free(path);
+	send_reply_read(xenstore, id, XS_RM, "");
 }
 
 static void handle_watch(struct xenstore *xenstore, uint32_t id, char *payload,

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -275,6 +275,7 @@ static struct xs_entry *key_to_entry(const char *key)
 	for (tok = strtok_r(key_buffer, "/", &tok_state);
 	     tok != NULL;
 	     tok = strtok_r(NULL, "/", &tok_state)) {
+		iter = NULL;
 		SYS_DLIST_FOR_EACH_CONTAINER_SAFE (inspected_list, iter, next, node) {
 			if (strcmp(iter->key, tok) == 0) {
 				break;
@@ -788,6 +789,7 @@ static int xss_do_write(const char *const_path, const char *data, uint32_t domid
 	parent_entry = &root_xenstore;
 
 	for (tok = strtok_r(path, "/", &tok_state); tok != NULL; tok = strtok_r(NULL, "/", &tok_state)) {
+		iter = NULL;
 		SYS_DLIST_FOR_EACH_CONTAINER(&parent_entry->child_list, iter, node) {
 			if (strcmp(iter->key, tok) == 0) {
 				break;
@@ -2032,4 +2034,3 @@ int xs_init_root(void)
 
 	return set_perms_by_array(&root_xenstore, &permissions, 1);
 }
-

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -674,22 +674,10 @@ static struct xs_permissions *deserialize_perms(const char *strings, const size_
 	}
 
 	for (i = 0, j = 0; i < str_len && j < (*perms_num); j++) {
-		switch (ptr[i]) {
-		case 'w':
-			perms[j].perms = XS_PERM_WRITE;
-			break;
-		case 'r':
-			perms[j].perms = XS_PERM_READ;
-			break;
-		case 'b':
-			perms[j].perms = (XS_PERM_READ | XS_PERM_WRITE);
-			break;
-		case 'n':
-			perms[j].perms = XS_PERM_NONE;
-			break;
-		default:
+		if (xenstore_perm_from_char(ptr[i], &perms[j].perms)) {
 			goto err_free;
 		}
+
 		if (i + 1 >= str_len) {
 			goto err_free;
 		}
@@ -1261,20 +1249,6 @@ static void handle_control(struct xenstore *xenstore, uint32_t id,
 	send_reply(xenstore, id, XS_CONTROL, "OK");
 }
 
-static char perm_to_char(const uint32_t perm)
-{
-	switch (perm & XS_PERM_BOTH) {
-	case XS_PERM_WRITE:
-		return 'w';
-	case XS_PERM_READ:
-		return 'r';
-	case XS_PERM_BOTH:
-		return 'b';
-	default:
-		return 'n';
-	}
-}
-
 /* The function allocates memory for the buffer, that should be freed by caller */
 static char *serialize_perms(struct xs_entry *entry, size_t *total_size)
 {
@@ -1300,7 +1274,7 @@ static char *serialize_perms(struct xs_entry *entry, size_t *total_size)
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&entry->perms, iter, node) {
 		curr_len = snprintf(&perm_str[*total_size], UINT32_MAX_STR_LEN + 1, "%c%u",
-				    perm_to_char(iter->perms), iter->domid);
+				    xenstore_perm_to_char(iter->perms), iter->domid);
 		/* Add size for terminating NULL */
 		*total_size += curr_len + 1;
 	}


### PR DESCRIPTION
# Automated testing results:

[xenstore_client_api.html](https://github.com/user-attachments/files/30263490/xenstore_client_api.html)

# Zephyr XenStore Client PR Note

## Summary

This PR adds a Zephyr XenStore client and the missing dom0less XenStore setup
needed for Zephyr Dom0/DomU XenStore communication.

The series has three main parts:

1. Dom0less XenStore page setup in `xen-dom-mgmt`
2. A Zephyr DomU XenStore client
3. Focused XenStore server/common fixes needed by the client validation

The first commit handles the dom0less handoff that Linux normally performs via
`init-dom0less`: Dom0 must make sure the guest has a real XenStore shared page
and that the XenStore server and guest client agree on the same `STORE_PFN` and
`STORE_EVTCHN`.

This is needed for both Xen 4.19-style and newer Xen 4.22-style setups, but
for slightly different reasons. With Xen 4.19, `STORE_PFN` may still be
`~0ULL`, meaning Xen provided the event-channel doorbell but did not provide a
usable XenStore shared page yet; Zephyr Dom0 must allocate and publish that
page before the guest client can talk to the server. With newer Xen, Xen may
already publish a real `STORE_PFN`; Zephyr must reuse that exact page instead
of deriving another page from legacy magic-page assumptions. In both cases the
fix makes Zephyr follow the guest-visible `STORE_EVTCHN` / `STORE_PFN`
contract so the Dom0 server and DomU client use the same mailbox and doorbell.

The client then maps the XenStore ring, binds the event channel, performs the
`RECONNECT -> CONNECTED` handshake, and exposes a public C API for the XenStore
operations currently validated against the local Zephyr XenStore server.

The transport was later extended with a dedicated RX thread. This is needed
because XenStore replies and asynchronous watch events arrive on the same
shared response ring. The RX thread is the single reader of that ring: it
routes normal replies by `req_id` to the waiting caller and dispatches watch
events to the registered callback.

## Supported Client Operations

The public client API currently supports:

| XenStore operation | Client API | Status |
| --- | --- | --- |
| Connect / handshake | `xs_client_connect()` | Supported |
| Connection state query | `xs_client_is_connected()` | Supported |
| `XS_READ` | `xs_client_read()` | Supported |
| `XS_WRITE` | `xs_client_write()` | Supported |
| `XS_DIRECTORY` | `xs_client_directory()` | Supported |
| `XS_MKDIR` | `xs_client_mkdir()` | Supported |
| `XS_RM` | `xs_client_rm()` | Supported |
| `XS_GET_PERMS` | `xs_client_get_perms()` | Supported |
| `XS_SET_PERMS` | `xs_client_set_perms()` | Supported |
| `XS_WATCH` | `xs_client_watch()` | Supported |
| `XS_UNWATCH` | `xs_client_unwatch()` | Supported |
| `XS_RESET_WATCHES` | `xs_client_reset_watches()` | Supported |
| `XS_GET_DOMAIN_PATH` | `xs_client_get_domain_path()` | Supported |
| Watch event delivery | `xs_client_set_watch_callback()` | Supported, single process-wide callback |

## Intentionally Not Exposed

The client does not expose transaction helpers yet.

The local Zephyr XenStore server accepts transaction message types, but it does
not implement real transaction semantics such as staging, commit, abort, or
rollback. Exposing transaction-aware client APIs would therefore promise
behavior the validated server side does not provide.

The client also does not expose `XS_CONTROL`.

The Zephyr server currently treats `XS_CONTROL` as a shallow transport/probe
acknowledgement, not as a real control-command implementation. Keeping it out
of the public client API avoids making this look like supported command
semantics.

## Watch Callback Model

The client supports multiple XenStore watch registrations, because XenStore
itself identifies watch events by `path + token`.

The current Zephyr API exposes one process-wide callback:

```c
void xs_client_set_watch_callback(xs_client_watch_cb_t cb, void *user_data);
```

Applications that register multiple watches should dispatch by token inside
that callback.

Callback replacement is synchronized. If an application thread replaces or
clears the callback while the RX thread is already executing it, the setter
waits for the active callback to finish. If the callback replaces itself from
the RX thread, it updates immediately to avoid self-deadlock.

## Validation

Runtime validation was run in QEMU/Xen with the Zephyr XenStore server in Dom0
and the Zephyr XenStore client in DomU.

Result:

```text
44/44 PASS
XENSTORE CLIENT TEST PASS
```

The generated validation report is:

```text
zephyr-xenstore-client/dev/qemu-xen-zephyr-dom0-validation/reports/xenstore_client_api.html
```

The validation covers positive and negative cases for the public client API,
including connection, read/write, directory, mkdir, remove, permissions,
watches, watch callback delivery, reset watches, domain path lookup, and
concurrent callers.

----

