### PR TITLE
ci: make fork PR builder checks reliable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
 
 env:
   sdk_version: ${{ vars.SDK_VERSION  || '0.16.5-1' }}
@@ -79,7 +79,6 @@ jobs:
       - name: Check out zephyr-xenlib
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           path: zephyr-xenlib
 
       - name: Build zephyr-dom0-xt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install west pyelftools protobuf grpcio-tools
-          sudo apt-get install ninja-build protobuf-compiler gperf
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build protobuf-compiler gperf
 
       - name: Cache Zephyr SDK
         id: cache-sdk


### PR DESCRIPTION
ci: use pull_request for PR builders

Run PR builders in the pull_request context so fork pull
request code is checked out with the restricted pull request token.

The previous pull_request_target workflow runs in the trusted base
repository context. That context refuses the unsafe fork-head checkout
pattern used by this workflow, which prevents fork PR validation from
starting.

----

ci: refresh apt dependencies for builders

Refresh the apt package index before installing runner packages and
pass -y so the install step can run in non-interactive CI.

Install cmake with the other host tools because Zephyr SDK setup
requires it before the project build starts.